### PR TITLE
Eflumerf/initial zmq implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(DAQ)
 daq_setup_environment()
 
 find_package(appfwk REQUIRED)
+find_package(cppzmq REQUIRED)
 
 ##############################################################################
 daq_point_build_to( include )  
@@ -15,8 +16,8 @@ daq_point_build_to( include )
 ##############################################################################
 daq_point_build_to( src )
 
-add_library(IPM src/Direct.cpp src/Publisher.cpp src/Subscriber.cpp)
-target_link_libraries(IPM appfwk::appfwk)
+add_library(IPM src/Direct.cpp src/Publisher.cpp src/Subscriber.cpp src/ZmqSender.cpp src/ZmqReceiver.cpp)
+target_link_libraries(IPM appfwk::appfwk ${ZMQ})
 
 ##############################################################################
 daq_point_build_to( test )
@@ -34,5 +35,7 @@ daq_add_unit_test(ipmReceiver_test IPM )
 daq_add_unit_test(Direct_test    IPM )
 daq_add_unit_test(Publisher_test    IPM )
 daq_add_unit_test(Subscriber_test    IPM )
+daq_add_unit_test(ZmqReceiver_test IPM)
+daq_add_unit_test(ZmqSender_test IPM)
 
 daq_install(TARGETS IPM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,15 @@ target_link_libraries(IPM appfwk::appfwk ${ZMQ})
 ##############################################################################
 daq_point_build_to( test )
 
-add_library(IPMReceiver_duneDAQModule test/IPMReceiver_duneDAQModule.cpp)
-target_link_libraries(IPMReceiver_duneDAQModule appfwk::appfwk)
-add_library(IPMSender_duneDAQModule test/IPMSender_duneDAQModule.cpp)
-target_link_libraries(IPMSender_duneDAQModule appfwk::appfwk)
+add_library(ipm_VectorIntIPMSender_duneDAQModule test/VectorIntIPMSenderDAQModule.cpp)
+target_link_libraries(ipm_VectorIntIPMSender_duneDAQModule IPM)
+
+add_library(ipm_VectorIntIPMReceiver_duneDAQModule test/VectorIntIPMReceiverDAQModule.cpp)
+target_link_libraries(ipm_VectorIntIPMReceiver_duneDAQModule IPM)
+
+file(COPY test/singleProcess.json DESTINATION test)
+file(COPY test/simpleZmqSender.json DESTINATION test)
+file(COPY test/simpleZmqReceiver.json DESTINATION test)
 
 ##############################################################################
 daq_point_build_to( unittest )

--- a/include/ipm/Direct.hpp
+++ b/include/ipm/Direct.hpp
@@ -21,8 +21,8 @@ class Direct
   , public ipmReceiver
 {
 public:
-  virtual void connect_for_sends(const nlohmann::json& /* connection_info */) override {}
-  virtual void connect_for_receives(const nlohmann::json& /* connection info */) override {}
+  void connect_for_sends(const nlohmann::json& /* connection_info */) override {}
+  void connect_for_receives(const nlohmann::json& /* connection info */) override {}
   bool can_send() const noexcept override { return false; }
   bool can_receive() const noexcept override { return false; }
 

--- a/include/ipm/Publisher.hpp
+++ b/include/ipm/Publisher.hpp
@@ -16,7 +16,7 @@ namespace dunedaq::ipm {
 class Publisher : public ipmSender
 {
 public:
-  virtual void connect_for_sends(const nlohmann::json& /* connection_info */) override {}
+  void connect_for_sends(const nlohmann::json& /* connection_info */) override {}
   bool can_send() const noexcept override { return false; }
 
 protected:

--- a/include/ipm/ZmqContext.hpp
+++ b/include/ipm/ZmqContext.hpp
@@ -1,0 +1,41 @@
+#ifndef IPM_INCLUDE_IPM_ZMQCONTEXT_HPP_
+#define IPM_INCLUDE_IPM_ZMQCONTEXT_HPP_
+
+/**
+ *
+ * @file ZmqContext.hpp ZmqContext Singleton class for hosting 0MQ context
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include <zmq.hpp>
+
+namespace dunedaq::ipm {
+class ZmqContext
+{
+public:
+  static ZmqContext& instance()
+  {
+    static ZmqContext ctx;
+    return ctx;
+  }
+
+  zmq::context_t& GetContext() { return context_; }
+  private:
+  ZmqContext() {}
+    ~ZmqContext()
+    {
+      context_.close();
+    }
+    zmq::context_t context_;
+
+    ZmqContext(ZmqContext const&) = delete;
+    ZmqContext(ZmqContext&&) = delete;
+    ZmqContext& operator=(ZmqContext const&) = delete;
+    ZmqContext& operator=(ZmqContext&&) = delete;
+};
+} // namespace dunedaq::ipm
+
+#endif // IPM_INCLUDE_IPM_ZMQCONTEXT_HPP_

--- a/include/ipm/ZmqReceiver.hpp
+++ b/include/ipm/ZmqReceiver.hpp
@@ -1,0 +1,41 @@
+/**
+ *
+ * @file ZmqReceiver.cpp ZmqReceiver messaging class declarations
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef IPM_INCLUDE_IPM_ZMQRECEIVER_HPP_
+#define IPM_INCLUDE_IPM_ZMQRECEIVER_HPP_
+
+#include "ipm/ZmqContext.hpp"
+#include "ipm/ipmReceiver.hpp"
+
+#include <zmq.hpp>
+#include <vector>
+
+namespace dunedaq {
+namespace ipm {
+class ZmqReceiver : public ipmReceiver
+{
+public:
+  ZmqReceiver()
+    : socket_(ZmqContext::instance().GetContext(), zmq::socket_type::pull)
+  {}
+  bool can_receive() const noexcept override;
+  void connect_for_receives(const nlohmann::json& connection_info);
+
+protected:
+  std::vector<char> receive_(const duration_type& timeout) override;
+
+private:
+  zmq::socket_t socket_;
+  bool socket_connected_{ false };
+};
+
+} // namespace ipm
+} // namespace dunedaq
+
+#endif // IPM_INCLUDE_IPM_ZMQRECEIVER_HPP_

--- a/include/ipm/ZmqSender.hpp
+++ b/include/ipm/ZmqSender.hpp
@@ -1,0 +1,40 @@
+/**
+ *
+ * @file ZmqSender.hpp ZmqSender messaging class declarations
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef IPM_INCLUDE_IPM_ZMQSENDER_HPP_
+#define IPM_INCLUDE_IPM_ZMQSENDER_HPP_
+
+#include "ipm/ipmSender.hpp"
+#include "ipm/ZmqContext.hpp"
+
+#include <zmq.hpp>
+
+namespace dunedaq {
+namespace ipm {
+class ZmqSender : public ipmSender
+{
+public:
+  ZmqSender()
+    : socket_(ZmqContext::instance().GetContext(), zmq::socket_type::push)
+  {}
+  bool can_send() const noexcept override;
+  void connect_for_sends(const nlohmann::json& connection_info);
+
+protected:
+  void send_(const void* message, int N, const duration_type& timeout) override;
+
+private:
+  zmq::socket_t socket_;
+  bool socket_connected_;
+};
+
+} // namespace ipm
+} // namespace dunedaq
+
+#endif // IPM_INCLUDE_IPM_ZMQSENDER_HPP_

--- a/src/IPMReceiverDAQModule.cpp.in
+++ b/src/IPMReceiverDAQModule.cpp.in
@@ -1,0 +1,9 @@
+#include "appfwk/IPMReceiverDAQModule.hpp"
+
+namespace dunedaq::appfwk {
+
+typedef dunedaq::appfwk::IPMReceiverDAQModule<@MAKE_DATATYPE_CPPTYPE@>
+  @MAKE_DATATYPE_PREFIX@IPMReceiverDAQModule;
+}
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::appfwk::@MAKE_DATATYPE_PREFIX@IPMReceiverDAQModule)

--- a/src/IPMSenderDAQModule.cpp.in
+++ b/src/IPMSenderDAQModule.cpp.in
@@ -1,0 +1,9 @@
+#include "appfwk/IPMSenderDAQModule.hpp"
+
+namespace dunedaq::appfwk {
+
+typedef dunedaq::appfwk::IPMSenderDAQModule<@MAKE_DATATYPE_CPPTYPE@>
+  @MAKE_DATATYPE_PREFIX@IPMSenderDAQModule;
+}
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::appfwk::@MAKE_DATATYPE_PREFIX@IPMSenderDAQModule)

--- a/src/ZmqReceiver.cpp
+++ b/src/ZmqReceiver.cpp
@@ -1,0 +1,54 @@
+/**
+ *
+ * @file ZmqReceiver.cpp ZmqReceiver messaging class definitions
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "ipm/ZmqContext.hpp"
+#include "ipm/ipmReceiver.hpp"
+
+#include <zmq.hpp>
+#include <vector>
+
+namespace dunedaq {
+namespace ipm {
+class ZmqReceiver : public ipmReceiver
+{
+public:
+  ZmqReceiver()
+    : socket_(ZmqContext::instance().GetContext(), zmq::socket_type::pull)
+  {}
+  bool can_receive() const noexcept override;
+
+protected:
+  std::vector<char> receive_(const duration_type& timeout) override;
+
+private:
+  zmq::socket_t socket_;
+  bool socket_connected_{ false };
+};
+
+bool
+ZmqReceiver::can_receive() const noexcept
+{
+  return socket_connected_;
+}
+
+std::vector<char>
+ZmqReceiver::receive_(const duration_type&)
+{
+  std::vector<char> output;
+  zmq::message_t msg;
+  auto res = socket_.recv(&msg);
+  if (res) {
+    output = std::vector<char>(msg.size());
+    memcpy(&output[0], msg.data(), msg.size());
+  }
+  return output;
+}
+
+} // namespace ipm
+} // namespace dunedaq

--- a/src/ZmqReceiver.cpp
+++ b/src/ZmqReceiver.cpp
@@ -7,34 +7,30 @@
  * received with this code.
  */
 
-#include "ipm/ZmqContext.hpp"
-#include "ipm/ipmReceiver.hpp"
+#include "ipm/ZmqReceiver.hpp"
 
+#include "TRACE/trace.h"
+#define TRACE_NAME "ZmqReceiver"
 #include <zmq.hpp>
 #include <vector>
+#include <string>
 
 namespace dunedaq {
 namespace ipm {
-class ZmqReceiver : public ipmReceiver
-{
-public:
-  ZmqReceiver()
-    : socket_(ZmqContext::instance().GetContext(), zmq::socket_type::pull)
-  {}
-  bool can_receive() const noexcept override;
-
-protected:
-  std::vector<char> receive_(const duration_type& timeout) override;
-
-private:
-  zmq::socket_t socket_;
-  bool socket_connected_{ false };
-};
 
 bool
 ZmqReceiver::can_receive() const noexcept
 {
   return socket_connected_;
+}
+
+void
+ZmqReceiver::connect_for_receives(const nlohmann::json& connection_info)
+{
+  std::string connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
+  TLOG(TLVL_INFO) << "Connection String is " << connection_string;
+  socket_.bind(connection_string);
+  socket_connected_ = true;
 }
 
 std::vector<char>

--- a/src/ZmqSender.cpp
+++ b/src/ZmqSender.cpp
@@ -7,33 +7,28 @@
  * received with this code.
  */
 
-#include "ipm/ipmSender.hpp"
-#include "ipm/ZmqContext.hpp"
+#include "ipm/ZmqSender.hpp"
 
-#include <zmq.hpp>
+#include "TRACE/trace.h"
+#define TRACE_NAME "ZmqSender"
+#include <string>
 
 namespace dunedaq {
 namespace ipm {
-class ZmqSender : public ipmSender
-{
-public:
-  ZmqSender()
-    : socket_(ZmqContext::instance().GetContext(), zmq::socket_type::push)
-  {}
-  bool can_send() const noexcept override;
-
-protected:
-  void send_(const void* message, int N, const duration_type& timeout) override;
-
-private:
-  zmq::socket_t socket_;
-  bool socket_connected_;
-};
 
 bool
 ZmqSender::can_send() const noexcept
 {
   return socket_connected_;
+}
+
+void
+ZmqSender::connect_for_sends(const nlohmann::json& connection_info)
+{
+  std::string connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
+  TLOG(TLVL_INFO) << "Connection String is " << connection_string;
+  socket_.connect(connection_string);
+  socket_connected_ = true;
 }
 
 void

--- a/src/ZmqSender.cpp
+++ b/src/ZmqSender.cpp
@@ -1,0 +1,47 @@
+/**
+ *
+ * @file ZmqSender.cpp ZmqSender messaging class definitions
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "ipm/ipmSender.hpp"
+#include "ipm/ZmqContext.hpp"
+
+#include <zmq.hpp>
+
+namespace dunedaq {
+namespace ipm {
+class ZmqSender : public ipmSender
+{
+public:
+  ZmqSender()
+    : socket_(ZmqContext::instance().GetContext(), zmq::socket_type::push)
+  {}
+  bool can_send() const noexcept override;
+
+protected:
+  void send_(const void* message, int N, const duration_type& timeout) override;
+
+private:
+  zmq::socket_t socket_;
+  bool socket_connected_;
+};
+
+bool
+ZmqSender::can_send() const noexcept
+{
+  return socket_connected_;
+}
+
+void
+ZmqSender::send_(const void* message, int N, const duration_type& )
+{
+  zmq::message_t msg(message, N);
+  socket_.send(msg);
+}
+
+} // namespace ipm
+} // namespace dunedaq

--- a/test/IPMReceiver_duneDAQModule.cpp
+++ b/test/IPMReceiver_duneDAQModule.cpp
@@ -1,8 +1,0 @@
-/**
- *
- * @file IPMReceiver_duneDAQModule.cpp Test implementation of a IPM Receiver DAQ Module (either direct or pub/sub mode)
- *
- * This is part of the DUNE DAQ Application Framework, copyright 2020.
- * Licensing/copyright details are in the COPYING file that you should have
- * received with this code.
- */

--- a/test/IPMSender_duneDAQModule.cpp
+++ b/test/IPMSender_duneDAQModule.cpp
@@ -1,8 +1,0 @@
-/**
- *
- * @file IPMSender_duneDAQModule.cpp Test implementation of a IPM Sender DAQ Module (either direct or pub/sub mode)
- *
- * This is part of the DUNE DAQ Application Framework, copyright 2020.
- * Licensing/copyright details are in the COPYING file that you should have
- * received with this code.
- */

--- a/test/VectorIntIPMReceiverDAQModule.cpp
+++ b/test/VectorIntIPMReceiverDAQModule.cpp
@@ -1,0 +1,110 @@
+/**
+ * @file VectorIntIPMReceiverDAQModule.cc VectorIntIPMReceiverDAQModule class
+ * implementation
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "VectorIntIPMReceiverDAQModule.hpp"
+
+#include "ipm/ZmqReceiver.hpp"
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <TRACE/trace.h>
+/**
+ * @brief Name used by TRACE TLOG calls from this source file
+ */
+#define TRACE_NAME "VectorIntIPMReceiver" // NOLINT
+
+namespace dunedaq {
+namespace ipm {
+
+VectorIntIPMReceiverDAQModule::VectorIntIPMReceiverDAQModule(const std::string& name)
+  : appfwk::DAQModule(name)
+  , thread_(std::bind(&VectorIntIPMReceiverDAQModule::do_work, this, std::placeholders::_1))
+  , outputQueue_(nullptr)
+  , queueTimeout_(100)
+{
+
+  register_command("configure", &VectorIntIPMReceiverDAQModule::do_configure);
+  register_command("start", &VectorIntIPMReceiverDAQModule::do_start);
+  register_command("stop", &VectorIntIPMReceiverDAQModule::do_stop);
+}
+
+void
+VectorIntIPMReceiverDAQModule::init()
+{
+  outputQueue_.reset(new appfwk::DAQSink<std::vector<int>>(get_config()["output"].get<std::string>()));
+  std::string receiver_type = get_config().value<std::string>("receiver_type", "Zmq");
+  
+  if (receiver_type == "Zmq") {
+      input_.reset(new ZmqReceiver());
+  }
+}
+
+void
+VectorIntIPMReceiverDAQModule::do_configure(const std::vector<std::string>& /*args*/)
+{
+  nIntsPerVector_ = get_config().value<int>("nIntsPerVector", 10);
+  queueTimeout_ = std::chrono::milliseconds(get_config().value<int>("queue_timeout_ms", 100));
+  input_->connect_for_receives(get_config());
+}
+
+void
+VectorIntIPMReceiverDAQModule::do_start(const std::vector<std::string>& /*args*/)
+{
+  thread_.start_working_thread();
+}
+
+void
+VectorIntIPMReceiverDAQModule::do_stop(const std::vector<std::string>& /*args*/)
+{
+  thread_.stop_working_thread();
+}
+
+void
+VectorIntIPMReceiverDAQModule::do_work(std::atomic<bool>& running_flag)
+{
+  size_t counter = 0;
+  std::ostringstream oss;
+
+  while (running_flag.load()) {
+    if (input_->can_receive()) {
+
+      TLOG(TLVL_TRACE) << get_name() << ": Creating output vector";
+      std::vector<int> output(nIntsPerVector_);
+
+      auto recvd = input_->receive(queueTimeout_);
+      assert(recvd.size() == nIntsPerVector_ * sizeof(int));
+      memcpy(&output[0], &recvd[0], sizeof(int) * nIntsPerVector_);
+
+      oss << ": Received vector " << counter << " with size " << output.size();
+      ers::info(ReceiverProgressUpdate(ERS_HERE, get_name(), oss.str()));
+      oss.str("");
+
+      TLOG(TLVL_TRACE) << get_name() << ": Pushing vector into outputQueue";
+      try {
+        outputQueue_->push(std::move(output), queueTimeout_);
+      } catch (const appfwk::QueueTimeoutExpired& ex) {
+        ers::warning(ex);
+      }
+
+      TLOG(TLVL_TRACE) << get_name() << ": End of do_work loop";
+      counter++;
+    } else {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+  }
+}
+
+} // namespace ipm
+} // namespace dunedaq
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::ipm::VectorIntIPMReceiverDAQModule)

--- a/test/VectorIntIPMReceiverDAQModule.hpp
+++ b/test/VectorIntIPMReceiverDAQModule.hpp
@@ -1,0 +1,78 @@
+/**
+ * @file VectorIntIPMReceiverDAQModule.hpp
+ *
+ * VectorIntIPMReceiverDAQModule receives vectors of integers from VectorIntIPMSenderDAQModule
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef IPM_TEST_VECTORINTIPMRECEIVERDAQMODULE_HPP_
+#define IPM_TEST_VECTORINTIPMRECEIVERDAQMODULE_HPP_
+
+#include "appfwk/DAQModule.hpp"
+#include "appfwk/DAQSink.hpp"
+#include "appfwk/ThreadHelper.hpp"
+#include "ipm/ipmReceiver.hpp"
+
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dunedaq {
+namespace ipm {
+/**
+ * @brief VectorIntIPMReceiverDAQModule creates vectors of ints and sends them
+ * downstream
+ */
+class VectorIntIPMReceiverDAQModule : public appfwk::DAQModule
+{
+public:
+  /**
+   * @brief VectorIntIPMReceiverDAQModule Constructor
+   * @param name Instance name for this VectorIntIPMReceiverDAQModule instance
+   */
+  explicit VectorIntIPMReceiverDAQModule(const std::string& name);
+
+  VectorIntIPMReceiverDAQModule(const VectorIntIPMReceiverDAQModule&) =
+    delete; ///< VectorIntIPMReceiverDAQModule is not copy-constructible
+  VectorIntIPMReceiverDAQModule& operator=(const VectorIntIPMReceiverDAQModule&) =
+    delete; ///< VectorIntIPMReceiverDAQModule is not copy-assignable
+  VectorIntIPMReceiverDAQModule(VectorIntIPMReceiverDAQModule&&) =
+    delete; ///< VectorIntIPMReceiverDAQModule is not move-constructible
+  VectorIntIPMReceiverDAQModule& operator=(VectorIntIPMReceiverDAQModule&&) =
+    delete; ///< VectorIntIPMReceiverDAQModule is not move-assignable
+
+  void init() override;
+
+private:
+  // Commands
+  void do_configure(const std::vector<std::string>& args);
+  void do_start(const std::vector<std::string>& args);
+  void do_stop(const std::vector<std::string>& args);
+
+  // Threading
+  appfwk::ThreadHelper thread_;
+  void do_work(std::atomic<bool>& running_flag);
+
+  // Configuration
+  std::unique_ptr<ipmReceiver> input_;
+  std::unique_ptr<appfwk::DAQSink<std::vector<int>>> outputQueue_;
+  std::chrono::milliseconds queueTimeout_;
+  size_t nIntsPerVector_ = 999;
+
+  size_t wait_between_sends_ms_ = 999;
+};
+} // namespace ipm
+
+ERS_DECLARE_ISSUE_BASE(ipm,
+                       ReceiverProgressUpdate,
+                       appfwk::GeneralDAQModuleIssue,
+                       message,
+                       ((std::string)name),
+                       ((std::string)message))
+} // namespace dunedaq
+
+#endif // IPM_TEST_VECTORINTIPMRECEIVERDAQMODULE_HPP_

--- a/test/VectorIntIPMSenderDAQModule.cpp
+++ b/test/VectorIntIPMSenderDAQModule.cpp
@@ -1,0 +1,107 @@
+/**
+ * @file VectorIntIPMSenderDAQModule.cxx VectorIntIPMSenderDAQModule class
+ * implementation
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "VectorIntIPMSenderDAQModule.hpp"
+
+#include "ipm/ZmqSender.hpp"
+
+#include "TRACE/trace.h"
+#include <ers/ers.h>
+
+/**
+ * @brief Name used by TRACE TLOG calls from this source file
+ */
+#define TRACE_NAME "VectorIntIPMSender" // NOLINT
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace dunedaq::ipm {
+
+VectorIntIPMSenderDAQModule::VectorIntIPMSenderDAQModule(const std::string& name)
+  : appfwk::DAQModule(name)
+  , thread_(std::bind(&VectorIntIPMSenderDAQModule::do_work, this, std::placeholders::_1))
+  , queueTimeout_(100)
+  , inputQueue_(nullptr)
+{
+
+  register_command("configure", &VectorIntIPMSenderDAQModule::do_configure);
+  register_command("start", &VectorIntIPMSenderDAQModule::do_start);
+  register_command("stop", &VectorIntIPMSenderDAQModule::do_stop);
+}
+
+void
+VectorIntIPMSenderDAQModule::init()
+{
+  inputQueue_.reset(new appfwk::DAQSource<std::vector<int>>(get_config()["input"].get<std::string>()));
+  std::string sender_type = get_config().value<std::string>("sender_type", "Zmq");
+
+  if (sender_type == "Zmq") {
+    output_.reset(new ZmqSender());
+  }
+}
+
+void
+VectorIntIPMSenderDAQModule::do_configure(const std::vector<std::string>& /*args*/)
+{
+
+  nIntsPerVector_ = get_config().value<int>("nIntsPerVector", 10);
+  queueTimeout_ = std::chrono::milliseconds(get_config().value<int>("queue_timeout_ms", 100));
+  output_->connect_for_sends(get_config());
+}
+
+void
+VectorIntIPMSenderDAQModule::do_start(const std::vector<std::string>& /*args*/)
+{
+  thread_.start_working_thread();
+}
+
+void
+VectorIntIPMSenderDAQModule::do_stop(const std::vector<std::string>& /*args*/)
+{
+  thread_.stop_working_thread();
+}
+
+void
+VectorIntIPMSenderDAQModule::do_work(std::atomic<bool>& running_flag)
+{
+  int counter = 0;
+  std::vector<int> vec;
+  std::ostringstream oss;
+
+  while (running_flag.load()) {
+    if (inputQueue_->can_pop() && output_->can_send()) {
+
+      TLOG(TLVL_TRACE) << get_name() << ": Going to receive data from inputQueue";
+
+      try {
+        inputQueue_->pop(vec, queueTimeout_);
+      } catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt) {
+        continue;
+      }
+
+      TLOG(TLVL_TRACE) << get_name() << ": Received vector of size " << vec.size() << " from queue, sending";
+      output_->send(&vec[0], vec.size() * sizeof(int), queueTimeout_);
+
+      counter++;
+      oss << ": Sent " << counter << " vectors";
+      ers::info(SenderProgressUpdate(ERS_HERE, get_name(), oss.str()));
+      oss.str("");
+    } else {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+  }
+}
+
+} // namespace dunedaq::ipm
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::ipm::VectorIntIPMSenderDAQModule)

--- a/test/VectorIntIPMSenderDAQModule.hpp
+++ b/test/VectorIntIPMSenderDAQModule.hpp
@@ -1,0 +1,79 @@
+/**
+ * @file VectorIntIPMSenderDAQModule.hpp
+ *
+ * VectorIntIPMSenderDAQModule is a simple DAQModule implementation that sends vectors of integers to
+ * VectorIntIPMReceiverDAQModule
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef IPM_TEST_VECTORINTIPMSENDERDAQMODULE_HPP_
+#define IPM_TEST_VECTORINTIPMSENDERDAQMODULE_HPP_
+
+#include "appfwk/DAQModule.hpp"
+#include "appfwk/DAQSource.hpp"
+#include "appfwk/ThreadHelper.hpp"
+#include "ipm/ipmSender.hpp"
+
+#include <ers/Issue.h>
+
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dunedaq {
+namespace ipm {
+/**
+ * @brief VectorIntIPMSenderDAQModule creates vectors of ints and sends them
+ * downstream
+ */
+class VectorIntIPMSenderDAQModule : public appfwk::DAQModule
+{
+public:
+  /**
+   * @brief VectorIntIPMSenderDAQModule Constructor
+   * @param name Instance name for this VectorIntIPMSenderDAQModule instance
+   */
+  explicit VectorIntIPMSenderDAQModule(const std::string& name);
+
+  VectorIntIPMSenderDAQModule(const VectorIntIPMSenderDAQModule&) =
+    delete; ///< VectorIntIPMSenderDAQModule is not copy-constructible
+  VectorIntIPMSenderDAQModule& operator=(const VectorIntIPMSenderDAQModule&) =
+    delete; ///< VectorIntIPMSenderDAQModule is not copy-assignable
+  VectorIntIPMSenderDAQModule(VectorIntIPMSenderDAQModule&&) =
+    delete; ///< VectorIntIPMSenderDAQModule is not move-constructible
+  VectorIntIPMSenderDAQModule& operator=(VectorIntIPMSenderDAQModule&&) =
+    delete; ///< VectorIntIPMSenderDAQModule is not move-assignable
+
+  void init() override;
+
+private:
+  // Commands
+  void do_configure(const std::vector<std::string>& args);
+  void do_start(const std::vector<std::string>& args);
+  void do_stop(const std::vector<std::string>& args);
+
+  // Threading
+  void do_work(std::atomic<bool>& running_flag);
+  appfwk::ThreadHelper thread_;
+
+  // Configuration (for validation)
+  size_t nIntsPerVector_ = 999;
+  std::chrono::milliseconds queueTimeout_;
+  std::unique_ptr<appfwk::DAQSource<std::vector<int>>> inputQueue_;
+  std::unique_ptr<ipmSender> output_;
+};
+
+} // namespace ipm
+ERS_DECLARE_ISSUE_BASE(ipm,
+                       SenderProgressUpdate,
+                       appfwk::GeneralDAQModuleIssue,
+                       message,
+                       ((std::string)name),
+                       ((std::string)message))
+} // namespace dunedaq
+
+#endif // IPM_TEST_VECTORINTIPMSENDERDAQMODULE_HPP_

--- a/test/simpleZmqReceiver.json
+++ b/test/simpleZmqReceiver.json
@@ -1,0 +1,20 @@
+{
+  "queues": {
+    "receiverToConsumer": {
+      "capacity": 5,
+      "kind": "StdDeQueue"
+    }
+  },
+  "modules": {
+    "receiver": {
+      "user_module_type": "VectorIntIPMReceiver",
+      "output": "receiverToConsumer",
+      "connection_string": "tcp://*:35000"
+    },
+    "consumer": {
+      "user_module_type": "FakeDataConsumerDAQModule",
+      "input": "receiverToConsumer"
+    }
+  },
+  "commands": {}
+}

--- a/test/simpleZmqSender.json
+++ b/test/simpleZmqSender.json
@@ -1,0 +1,20 @@
+{
+  "queues": {
+    "producerToSender": {
+      "capacity": 10,
+      "kind": "StdDeQueue"
+    }
+  },
+  "modules": {
+    "producer": {
+      "user_module_type": "FakeDataProducerDAQModule",
+      "output": "producerToSender"
+    },
+    "sender": {
+      "user_module_type": "VectorIntIPMSender",
+      "input": "producerToSender",
+      "connection_string": "tcp://localhost:35000"
+    }
+  },
+  "commands": {}
+}

--- a/test/singleProcess.json
+++ b/test/singleProcess.json
@@ -1,0 +1,33 @@
+{
+  "queues": {
+    "producerToSender": {
+      "capacity": 10,
+      "kind": "StdDeQueue"
+    },
+    "receiverToConsumer": {
+      "capacity": 5,
+      "kind": "StdDeQueue"
+    }
+  },
+  "modules": {
+    "producer": {
+      "user_module_type": "FakeDataProducerDAQModule",
+      "output": "producerToSender"
+    },
+    "sender": {
+      "user_module_type": "VectorIntIPMSender",
+      "input": "producerToSender",
+      "connection_string": "inproc://test"
+    },
+    "receiver": {
+      "user_module_type": "VectorIntIPMReceiver",
+      "output": "receiverToConsumer",
+      "connection_string": "inproc://test"
+    },
+    "consumer": {
+      "user_module_type": "FakeDataConsumerDAQModule",
+      "input": "receiverToConsumer"
+    }
+  },
+  "commands": {}
+}

--- a/unittest/ZmqReceiver_test.cxx
+++ b/unittest/ZmqReceiver_test.cxx
@@ -1,0 +1,30 @@
+/**
+ *
+ * @file ZmqReceiver_test.cxx ZmqReceiver class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "../src/ZmqReceiver.cpp"
+
+#define BOOST_TEST_MODULE ZmqReceiver_test // NOLINT
+#include <boost/test/unit_test.hpp>
+
+#include <boost/asio/signal_set.hpp>
+
+#include <chrono>
+#include <memory>
+
+BOOST_AUTO_TEST_CASE(sanity_checks)
+{
+
+  std::unique_ptr<dunedaq::ipm::ZmqReceiver> umth_ptr = nullptr;
+
+  auto starttime = std::chrono::steady_clock::now();
+  BOOST_REQUIRE_NO_THROW(umth_ptr = std::make_unique<dunedaq::ipm::ZmqReceiver>());
+  auto construction_time_in_ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
+  BOOST_TEST_MESSAGE("Construction time was " << construction_time_in_ms << " ms");
+}

--- a/unittest/ZmqSender_test.cxx
+++ b/unittest/ZmqSender_test.cxx
@@ -1,0 +1,30 @@
+/**
+ *
+ * @file ZmqSender_test.cxx ZmqSender class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "../src/ZmqSender.cpp"
+
+#define BOOST_TEST_MODULE ZmqSender_test // NOLINT
+#include <boost/test/unit_test.hpp>
+
+#include <boost/asio/signal_set.hpp>
+
+#include <chrono>
+#include <memory>
+
+BOOST_AUTO_TEST_CASE(sanity_checks)
+{
+
+  std::unique_ptr<dunedaq::ipm::ZmqSender> umth_ptr = nullptr;
+
+  auto starttime = std::chrono::steady_clock::now();
+  BOOST_REQUIRE_NO_THROW(umth_ptr = std::make_unique<dunedaq::ipm::ZmqSender>());
+  auto construction_time_in_ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
+  BOOST_TEST_MESSAGE("Construction time was " << construction_time_in_ms << " ms");
+}

--- a/unittest/ipmReceiver_test.cxx
+++ b/unittest/ipmReceiver_test.cxx
@@ -30,7 +30,7 @@ public:
     : can_receive_(false)
   {}
 
-  void connect_for_receives(const nlohmann::json& /* connection_info */) {};
+  void connect_for_receives(const nlohmann::json& /* connection_info */) {}
   bool can_receive() const noexcept override { return can_receive_; }
   void make_me_ready_to_receive() { can_receive_ = true; }
   void sabotage_my_receiving_ability() { can_receive_ = false; }

--- a/unittest/ipmSender_test.cxx
+++ b/unittest/ipmSender_test.cxx
@@ -28,7 +28,7 @@ public:
     : can_send_(false)
   {}
 
-  void connect_for_sends(const nlohmann::json& /* connection_info */) {};
+  void connect_for_sends(const nlohmann::json& /* connection_info */) {}
   bool can_send() const noexcept override { return can_send_; }
   void make_me_ready_to_send() { can_send_ = true; }
   void sabotage_my_sending_ability() { can_send_ = false; }


### PR DESCRIPTION
This PR constitutes an initial implementation of a ZmqSender ipmSender implementation and a ZmqReceiver ipmReceiver implementation. DAQModules which produce/consume std::vector<int> are also provided as well as daq_application configurations.