### PR TITLE
Fix the build for dependent packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(cppzmq REQUIRED)
 find_package(ers REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
+# We don't make a real library, but we need a target called ipm::ipm for dependents to depend on, so they can find the ipm headers
+daq_add_library(dummy.cpp LINK_LIBRARIES ${ZMQ} appfwk::appfwk)
+
 daq_add_plugin(ZmqSender duneIPM LINK_LIBRARIES ${ZMQ} appfwk::appfwk)
 daq_add_plugin(ZmqReceiver duneIPM LINK_LIBRARIES ${ZMQ} appfwk::appfwk)
 daq_add_plugin(ZmqPublisher duneIPM LINK_LIBRARIES ${ZMQ} appfwk::appfwk)

--- a/cmake/ipmConfig.cmake.in
+++ b/cmake/ipmConfig.cmake.in
@@ -12,8 +12,9 @@ find_package(nlohmann_json)
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 
-message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
-add_library(ipm::ipm ALIAS ipm)
+  message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
+
 
 else()
 

--- a/cmake/ipmConfig.cmake.in
+++ b/cmake/ipmConfig.cmake.in
@@ -7,7 +7,20 @@ find_dependency(appfwk)
 find_dependency(ers)
 find_package(nlohmann_json)
 
+# Figure out whether or not this dependency is an installed package or
+# in repo form
+
+if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
+
+message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
+add_library(ipm::ipm ALIAS ipm)
+
+else()
+
+message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
+
+endif()
 
 check_required_components(@PROJECT_NAME@)

--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -1,0 +1,1 @@
+// This file only exists so that the CMake build can create a library for this package, via the daq_add_library() CMake function


### PR DESCRIPTION
While trying to build my package connecting queues to the network, I ran into some build problems with the IPM dependency. One issue is that there's no ipm library, which means there's no `ipm::ipm` target to use as a dependency in order to get the IPM include directories. To work around that, I created a `src/dummy.cpp` file and made a library out of that. The correct cmake way to handle this case appears to be to create an `INTERFACE` library, but that would require manually setting the target options, whereas in my workaround, `daq_add_library()` does that for me.

The other change in this PR is to `ipmConfig.cmake.in` to handle the use-from-build-dir case, following the approach used in `cmdlib`