### PR TITLE
`ipmConfig.cmake.in` changes

### DIFF
--- a/cmake/ipmConfig.cmake.in
+++ b/cmake/ipmConfig.cmake.in
@@ -12,8 +12,9 @@ find_package(nlohmann_json)
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 
-message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
-add_library(ipm::ipm ALIAS ipm)
+  message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
+
 
 else()
 

--- a/cmake/ipmConfig.cmake.in
+++ b/cmake/ipmConfig.cmake.in
@@ -7,7 +7,20 @@ find_dependency(appfwk)
 find_dependency(ers)
 find_package(nlohmann_json)
 
+# Figure out whether or not this dependency is an installed package or
+# in repo form
+
+if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
+
+message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
+add_library(ipm::ipm ALIAS ipm)
+
+else()
+
+message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
+
+endif()
 
 check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
This PR modifies `ipmConfig.cmake.in` to match the scheme used in other packages so that the relevant targets can be found by dependent packages in either run-from-build-dir mode or installed mode. It relies on an `ipm` target existing, which needs some incoming changes from Eric