### PR TITLE
Make a `cppzmq::cppzmq` target in `Findcppzmq.cmake`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(cppzmq REQUIRED)
 find_package(ers REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
-daq_add_library(Receiver.cpp Sender.cpp LINK_LIBRARIES appfwk::appfwk)
+daq_add_library(Receiver.cpp Sender.cpp LINK_LIBRARIES appfwk::appfwk cppzmq::cppzmq)
 
 daq_add_plugin(ZmqSender duneIPM LINK_LIBRARIES ${ZMQ} ipm)
 daq_add_plugin(ZmqReceiver duneIPM LINK_LIBRARIES ${ZMQ} ipm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@ find_package(nlohmann_json REQUIRED)
 
 daq_add_library(Receiver.cpp Sender.cpp LINK_LIBRARIES appfwk::appfwk cppzmq::cppzmq)
 
-daq_add_plugin(ZmqSender duneIPM LINK_LIBRARIES ${ZMQ} ipm)
-daq_add_plugin(ZmqReceiver duneIPM LINK_LIBRARIES ${ZMQ} ipm)
-daq_add_plugin(ZmqPublisher duneIPM LINK_LIBRARIES ${ZMQ} ipm)
-daq_add_plugin(ZmqSubscriber duneIPM LINK_LIBRARIES ${ZMQ} ipm)
+daq_add_plugin(ZmqSender duneIPM LINK_LIBRARIES ipm)
+daq_add_plugin(ZmqReceiver duneIPM LINK_LIBRARIES ipm)
+daq_add_plugin(ZmqPublisher duneIPM LINK_LIBRARIES ipm)
+daq_add_plugin(ZmqSubscriber duneIPM LINK_LIBRARIES ipm)
 
 daq_add_plugin(VectorIntIPMSenderDAQModule duneDAQModule TEST LINK_LIBRARIES ipm)
 daq_add_plugin(VectorIntIPMReceiverDAQModule duneDAQModule TEST LINK_LIBRARIES ipm)

--- a/cmake/Findcppzmq.cmake
+++ b/cmake/Findcppzmq.cmake
@@ -1,15 +1,37 @@
 # JCF, Oct-19-2020
 # This is a snippet Eric created, posted in a Slack PM Sep-23-2020
+#
+# Modified by P. Rodrigues, 2020-11-17, based on the guidance in
+# https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html
 
 if(EXISTS $ENV{ZMQ_LIB})
- # UPS
- message("Finding CPPZMQ from UPS $ENV{ZMQ_LIB}")
-  include_directories($ENV{ZMQ_INC})
-  find_library(ZMQ NAMES libzmq.so HINTS $ENV{ZMQ_LIB})
-  message("find_library ZMQ found ${ZMQ}")
-  set(cppzmq_FOUND TRUE)
+  # UPS
+  message("Finding CPPZMQ from UPS $ENV{ZMQ_INC}")
+  find_path(cppzmq_INCLUDE_DIR
+    NAMES zmq.hpp
+    PATHS $ENV{ZMQ_INC}
+    )
+  message("Found zmq.hpp in ${cppzmq_INCLUDE_DIR}")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(cppzmq
+    FOUND_VAR cppzmq_FOUND
+    REQUIRED_VARS
+    cppzmq_INCLUDE_DIR
+    )
+  
+  if(cppzmq_FOUND AND NOT TARGET cppzmq::cppzmq)
+    # cppzmq is header-only, so we use an INTERFACE "library", as
+    # described in
+    # https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries
+    add_library(cppzmq::cppzmq INTERFACE IMPORTED)
+    set_target_properties(cppzmq::cppzmq PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${cppzmq_INCLUDE_DIR}"
+      )
+  endif()
+  
 else()
-	# Spack
-	find_package(cppzmq REQUIRED)
-	set(ZMQ zmq)
+  # Spack
+  find_package(cppzmq REQUIRED CONFIG)
 endif()
+

--- a/cmake/Findcppzmq.cmake
+++ b/cmake/Findcppzmq.cmake
@@ -13,11 +13,14 @@ if(EXISTS $ENV{ZMQ_LIB})
     )
   message("Found zmq.hpp in ${cppzmq_INCLUDE_DIR}")
 
+  find_library(ZMQ_LIBRARY NAMES libzmq.so HINTS $ENV{ZMQ_LIB})
+  
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(cppzmq
     FOUND_VAR cppzmq_FOUND
     REQUIRED_VARS
     cppzmq_INCLUDE_DIR
+    ZMQ_LIBRARY
     )
   
   if(cppzmq_FOUND AND NOT TARGET cppzmq::cppzmq)
@@ -28,6 +31,7 @@ if(EXISTS $ENV{ZMQ_LIB})
     set_target_properties(cppzmq::cppzmq PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${cppzmq_INCLUDE_DIR}"
       )
+    target_link_libraries(cppzmq::cppzmq INTERFACE ${ZMQ_LIBRARY})
   endif()
   
 else()


### PR DESCRIPTION
This PR modifies `Findcppzmq.cmake` to create a `cppzmq::cppzmq` target, so that packages depending on ipm don't have to manually depend on cppzmq. Strategy is as described here: https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html