### PR TITLE
Add inline specifier to header-defined make_ipm_* functions.

### DIFF
--- a/include/ipm/Receiver.hpp
+++ b/include/ipm/Receiver.hpp
@@ -102,7 +102,7 @@ protected:
   virtual Response receive_(const duration_t& timeout) = 0;
 };
 
-std::shared_ptr<Receiver>
+inline std::shared_ptr<Receiver>
 make_ipm_receiver(std::string const& plugin_name)
 {
   static cet::BasicPluginFactory bpf("duneIPM", "make");

--- a/include/ipm/Sender.hpp
+++ b/include/ipm/Sender.hpp
@@ -109,7 +109,7 @@ protected:
   }
 };
 
-std::shared_ptr<Sender>
+inline std::shared_ptr<Sender>
 make_ipm_sender(std::string const& plugin_name)
 {
   static cet::BasicPluginFactory bpf("duneIPM", "make");

--- a/include/ipm/Subscriber.hpp
+++ b/include/ipm/Subscriber.hpp
@@ -55,7 +55,7 @@ public:
   Subscriber& operator=(Subscriber&&) = delete;
 };
 
-std::shared_ptr<Subscriber>
+inline std::shared_ptr<Subscriber>
 make_ipm_subscriber(std::string const& plugin_name)
 {
   static cet::BasicPluginFactory bpf("duneIPM", "make");


### PR DESCRIPTION
When trying to build with Serialization and networkqueue, I noticed that the make_ipm_sender method was getting multiply defined. Since it is a header-defined method, it should have the inline specifier.