### PR TITLE
Make `Sender` and `Receiver` destructors virtual

### DIFF
--- a/include/ipm/Receiver.hpp
+++ b/include/ipm/Receiver.hpp
@@ -75,6 +75,8 @@ public:
 
   Receiver() = default;
 
+  virtual ~Receiver() = default;
+
   virtual void connect_for_receives(const nlohmann::json& connection_info) = 0;
 
   virtual bool can_receive() const noexcept = 0;

--- a/include/ipm/Sender.hpp
+++ b/include/ipm/Sender.hpp
@@ -71,6 +71,8 @@ public:
 
   Sender() = default;
 
+  virtual ~Sender() = default;
+
   virtual void connect_for_sends(const nlohmann::json& connection_info) = 0;
 
   virtual bool can_send() const noexcept = 0;

--- a/plugins/ZmqReceiverImpl.hpp
+++ b/plugins/ZmqReceiverImpl.hpp
@@ -35,6 +35,15 @@ public:
     : m_socket(ZmqContext::instance().GetContext(),
                type == ReceiverType::Pull ? zmq::socket_type::pull : zmq::socket_type::sub)
   {}
+
+  ~ZmqReceiverImpl()
+  {
+    // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
+    if (m_connection_string!="") {
+      m_socket.disconnect(m_connection_string);
+    }
+  }
+
   bool can_receive() const noexcept override { return m_socket_connected; }
   void connect_for_receives(const nlohmann::json& connection_info) override
   {

--- a/plugins/ZmqReceiverImpl.hpp
+++ b/plugins/ZmqReceiverImpl.hpp
@@ -42,6 +42,7 @@ public:
     if (m_connection_string!="") {
       m_socket.disconnect(m_connection_string);
     }
+    m_socket.close();
   }
 
   bool can_receive() const noexcept override { return m_socket_connected; }

--- a/plugins/ZmqReceiverImpl.hpp
+++ b/plugins/ZmqReceiverImpl.hpp
@@ -38,14 +38,14 @@ public:
   bool can_receive() const noexcept override { return m_socket_connected; }
   void connect_for_receives(const nlohmann::json& connection_info) override
   {
-    std::string connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
-    TLOG() << "Connection String is " << connection_string;
+    m_connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
+    TLOG() << "Connection String is " << m_connection_string;
     try {
       m_socket.setsockopt(ZMQ_RCVTIMEO, 1); // 1 ms, we'll repeat until we reach timeout
-      m_socket.connect(connection_string);
+      m_socket.connect(m_connection_string);
       m_socket_connected = true;
     } catch (zmq::error_t const& err) {
-      throw ZmqReceiverConnectError(ERS_HERE, err.what(), connection_string);
+      throw ZmqReceiverConnectError(ERS_HERE, err.what(), m_connection_string);
     }
   }
 

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -40,6 +40,7 @@ public:
     if (m_connection_string!="") {
       m_socket.unbind(m_connection_string);
     }
+    m_socket.close();
   }
 
   bool can_send() const noexcept override { return m_socket_connected; }

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -33,6 +33,15 @@ public:
     : m_socket(ZmqContext::instance().GetContext(),
                type == SenderType::Push ? zmq::socket_type::push : zmq::socket_type::pub)
   {}
+
+  ~ZmqSenderImpl()
+  {
+    // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
+    if (m_connection_string!="") {
+      m_socket.unbind(m_connection_string);
+    }
+  }
+
   bool can_send() const noexcept override { return m_socket_connected; }
   void connect_for_sends(const nlohmann::json& connection_info)
   {

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -36,15 +36,15 @@ public:
   bool can_send() const noexcept override { return m_socket_connected; }
   void connect_for_sends(const nlohmann::json& connection_info)
   {
-    std::string connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
-    TLOG() << "Connection String is " << connection_string;
+    m_connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
+    TLOG() << "Connection String is " << m_connection_string;
     try {
 
       m_socket.setsockopt(ZMQ_SNDTIMEO, 1); // 1 ms, we'll repeat until we reach timeout
-      m_socket.bind(connection_string);
+      m_socket.bind(m_connection_string);
       m_socket_connected = true;
     } catch (zmq::error_t const& err) {
-      throw ZmqSenderBindError(ERS_HERE, err.what(), connection_string);
+      throw ZmqSenderBindError(ERS_HERE, err.what(), m_connection_string);
     }
   }
 


### PR DESCRIPTION
`Sender` and `Receiver` dtors have to be virtual so that destructing derived classes via pointer-to-base works. This PR does that, and adds explicit socket disconnect/unbind at destruction, which might not actually be necessary, but maybe it's good to be explicit?

Needed to fix https://github.com/DUNE-DAQ/nwqueueadapters/issues/10