### PR TITLE
Allow IPM to resolve SRV records

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,10 @@ find_package(nlohmann_json REQUIRED)
 
 daq_add_library(Receiver.cpp Sender.cpp LINK_LIBRARIES appfwk::appfwk logging::logging cppzmq)
 
-daq_add_plugin(ZmqSender duneIPM LINK_LIBRARIES ipm)
-daq_add_plugin(ZmqReceiver duneIPM LINK_LIBRARIES ipm)
-daq_add_plugin(ZmqPublisher duneIPM LINK_LIBRARIES ipm)
-daq_add_plugin(ZmqSubscriber duneIPM LINK_LIBRARIES ipm)
+daq_add_plugin(ZmqSender duneIPM LINK_LIBRARIES ipm resolv)
+daq_add_plugin(ZmqReceiver duneIPM LINK_LIBRARIES ipm resolv)
+daq_add_plugin(ZmqPublisher duneIPM LINK_LIBRARIES ipm resolv)
+daq_add_plugin(ZmqSubscriber duneIPM LINK_LIBRARIES ipm resolv)
 
 daq_add_unit_test(Sender_test LINK_LIBRARIES ipm)
 daq_add_unit_test(Receiver_test LINK_LIBRARIES ipm)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Users should interact with IPM via the interfaces `dunedaq::ipm::Sender`, `duned
 * `ZmqPublisher` implementing `dunedaq::ipm::Sender` in the publisher/subscriber pattern
 * `ZmqSubscriber` implementing `dunedaq::ipm::Subscriber`
 
-Basic example of the sender/receiver pattern:
+## Basic example of the sender/receiver pattern:
 
 ```c++
 // Sender side
@@ -33,7 +33,7 @@ Receiver::Response response=receiver->receive(std::chrono::milliseconds(10));
 // ... do something with response.data or response.metadata
 ```
 
-Basic example of the publisher/subscriber pattern:
+## Basic example of the publisher/subscriber pattern:
 
 ```c++
 // Publisher side
@@ -54,3 +54,10 @@ Receiver::Response response=subscriber->receive(std::chrono::milliseconds(10));
 
 More complete examples can be found in the `test/plugins` directory.
 
+## ZMQ Configuration Parameters
+
+The ZmqSender, ZmqReceiver, ZmqSubscriber and ZmqPublisher plugins all take the same configuration options:
+
+* "connection_string": A ZMQ endpoint (usually of form tcp://IP:PORT, but other transports such as inproc may be used)
+* "service_name": To perform DNS SRV record lookup, the service name can be specified either completely (e.g. _fragments-0._tcp.dataflow) or simply (e.g. fragments-0)
+* "host_name": When specifying simple service_names, the host_name will be used to help build the complete service name: \_<service_name>.\_tcp.<host_name>_

--- a/include/ipm/Resolver.hpp
+++ b/include/ipm/Resolver.hpp
@@ -31,7 +31,7 @@ ERS_DECLARE_ISSUE(ipm,
                   ((std::string)name)((std::string)error))
 
 namespace ipm {
-  std::vector<std::string> GetServiceAddresses(std::string service_name)
+  std::vector<std::string> GetServiceAddresses(std::string service_name, std::string hostname)
   {
     std::vector<std::string> output;
     unsigned char query_buffer[1024];
@@ -39,9 +39,13 @@ namespace ipm {
     // Check if we're given a "bare" service name, convert to DNS service name, assuming TCP
     if(std::count(service_name.begin(), service_name.end(), '.') == 0) {
        service_name = "_" + service_name + "._tcp";
+
+       if (!hostname.empty()) {
+         service_name += "." + hostname;
+       }
     }
 
-    auto response = res_query(service_name.c_str(), C_IN, ns_t_srv, query_buffer, sizeof(query_buffer));
+    auto response = res_search(service_name.c_str(), C_IN, ns_t_srv, query_buffer, sizeof(query_buffer));
     if (response < 0) {
       ers::error(ServiceNotFound(ERS_HERE, service_name));
       return output;

--- a/include/ipm/Resolver.hpp
+++ b/include/ipm/Resolver.hpp
@@ -36,6 +36,11 @@ namespace ipm {
     std::vector<std::string> output;
     unsigned char query_buffer[1024];
 
+    // Check if we're given a "bare" service name, convert to DNS service name, assuming TCP
+    if(std::count(service_name.begin(), service_name.end(), '.') == 0) {
+       service_name = "_" + service_name + "._tcp";
+    }
+
     auto response = res_query(service_name.c_str(), C_IN, ns_t_srv, query_buffer, sizeof(query_buffer));
     if (response < 0) {
       ers::error(ServiceNotFound(ERS_HERE, service_name));

--- a/include/ipm/Resolver.hpp
+++ b/include/ipm/Resolver.hpp
@@ -18,6 +18,8 @@
 #include <netinet/in.h>
 #include <resolv.h>
 #include <sys/types.h>
+
+#include <string>
 #include <vector>
 
 namespace dunedaq {
@@ -29,7 +31,7 @@ ERS_DECLARE_ISSUE(ipm,
                   ((std::string)name)((std::string)error))
 
 namespace ipm {
-  static std::vector<std::string> GetServiceAddresses(std::string service_name)
+  std::vector<std::string> GetServiceAddresses(std::string service_name)
   {
     std::vector<std::string> output;
     unsigned char query_buffer[1024];
@@ -50,17 +52,17 @@ namespace ipm {
       char name[1024];
       dn_expand(ns_msg_base(nsMsg), ns_msg_end(nsMsg), ns_rr_rdata(rr) + 6, name, sizeof(name));
 
-      auto port = ntohs(*((unsigned short*)ns_rr_rdata(rr) + 2));
+      auto port = ntohs(*((unsigned short*)ns_rr_rdata(rr) + 2)); // NOLINT(runtime/int)
 
       struct addrinfo* result;
-      auto s = getaddrinfo(name, NULL, NULL, &result);
+      auto s = getaddrinfo(name, nullptr, nullptr, &result);
 
       if (s != 0) {
         ers::error(NameNotFound(ERS_HERE, name, std::string(gai_strerror(s))));
         continue;
       }
 
-      for (auto rp = result; rp != NULL; rp = rp->ai_next) {
+      for (auto rp = result; rp != nullptr; rp = rp->ai_next) {
         char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
         getnameinfo(
           rp->ai_addr, rp->ai_addrlen, hbuf, sizeof(hbuf), sbuf, sizeof(sbuf), NI_NUMERICHOST | NI_NUMERICSERV);

--- a/include/ipm/Resolver.hpp
+++ b/include/ipm/Resolver.hpp
@@ -29,20 +29,15 @@ ERS_DECLARE_ISSUE(ipm,
                   ((std::string)name)((std::string)error))
 
 namespace ipm {
-class Resolver
-{
-public:
   static std::vector<std::string> GetServiceAddresses(std::string service_name)
   {
     std::vector<std::string> output;
-    int response;
     unsigned char query_buffer[1024];
-    {
-      response = res_query(service_name.c_str(), C_IN, ns_t_srv, query_buffer, sizeof(query_buffer));
-      if (response < 0) {
-        ers::error(ServiceNotFound(ERS_HERE, service_name));
-        return output;
-      }
+
+    auto response = res_query(service_name.c_str(), C_IN, ns_t_srv, query_buffer, sizeof(query_buffer));
+    if (response < 0) {
+      ers::error(ServiceNotFound(ERS_HERE, service_name));
+      return output;
     }
 
     ns_msg nsMsg;
@@ -76,7 +71,6 @@ public:
     }
     return output;
   }
-};
 } // namespace ipm
 } // namespace dunedaq
 

--- a/include/ipm/Resolver.hpp
+++ b/include/ipm/Resolver.hpp
@@ -1,0 +1,83 @@
+#ifndef IPM_INCLUDE_IPM_RESOLVER_HPP_
+#define IPM_INCLUDE_IPM_RESOLVER_HPP_
+
+/**
+ *
+ * @file Resolver.hpp DNS Resolver methods
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "ers/Issue.hpp"
+#include "logging/Logging.hpp"
+
+#include <arpa/nameser.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <resolv.h>
+#include <sys/types.h>
+#include <vector>
+
+namespace dunedaq {
+
+ERS_DECLARE_ISSUE(ipm, ServiceNotFound, "The service " << service << " was not found in DNS", ((std::string)service))
+ERS_DECLARE_ISSUE(ipm,
+                  NameNotFound,
+                  "The hostname " << name << " could not be resolved: " << error,
+                  ((std::string)name)((std::string)error))
+
+namespace ipm {
+class Resolver
+{
+public:
+  static std::vector<std::string> GetServiceAddresses(std::string service_name)
+  {
+    std::vector<std::string> output;
+    int response;
+    unsigned char query_buffer[1024];
+    {
+      response = res_query(service_name.c_str(), C_IN, ns_t_srv, query_buffer, sizeof(query_buffer));
+      if (response < 0) {
+        ers::error(ServiceNotFound(ERS_HERE, service_name));
+        return output;
+      }
+    }
+
+    ns_msg nsMsg;
+    ns_initparse(query_buffer, response, &nsMsg);
+
+    for (int x = 0; x < ns_msg_count(nsMsg, ns_s_an); x++) {
+      ns_rr rr;
+      ns_parserr(&nsMsg, ns_s_an, x, &rr);
+
+      char name[1024];
+      dn_expand(ns_msg_base(nsMsg), ns_msg_end(nsMsg), ns_rr_rdata(rr) + 6, name, sizeof(name));
+
+      auto port = ntohs(*((unsigned short*)ns_rr_rdata(rr) + 2));
+
+      struct addrinfo* result;
+      auto s = getaddrinfo(name, NULL, NULL, &result);
+
+      if (s != 0) {
+        ers::error(NameNotFound(ERS_HERE, name, std::string(gai_strerror(s))));
+        continue;
+      }
+
+      for (auto rp = result; rp != NULL; rp = rp->ai_next) {
+        char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
+        getnameinfo(
+          rp->ai_addr, rp->ai_addrlen, hbuf, sizeof(hbuf), sbuf, sizeof(sbuf), NI_NUMERICHOST | NI_NUMERICSERV);
+        output.push_back(std::string(hbuf) + ":" + std::to_string(port));
+      }
+
+      freeaddrinfo(result);
+    }
+    return output;
+  }
+};
+} // namespace ipm
+} // namespace dunedaq
+
+#endif // IPM_INCLUDE_IPM_RESOLVER_HPP_

--- a/plugins/ZmqReceiverImpl.hpp
+++ b/plugins/ZmqReceiverImpl.hpp
@@ -57,7 +57,7 @@ public:
   {
     auto service_name = connection_info.value<std::string>("service_name", "");
     if (service_name != "") {
-      auto service_hosts = Resolver::GetServiceAddresses(service_name);
+      auto service_hosts = GetServiceAddresses(service_name);
       if (service_hosts.size() > 0) {
         m_connection_string = "tcp://" + service_hosts[0];
       }

--- a/plugins/ZmqReceiverImpl.hpp
+++ b/plugins/ZmqReceiverImpl.hpp
@@ -56,8 +56,9 @@ public:
   void connect_for_receives(const nlohmann::json& connection_info) override
   {
     auto service_name = connection_info.value<std::string>("service_name", "");
+    auto host_name = connection_info.value<std::string>("host_name", "");
     if (service_name != "") {
-      auto service_hosts = GetServiceAddresses(service_name);
+      auto service_hosts = GetServiceAddresses(service_name, host_name);
       if (service_hosts.size() > 0) {
         m_connection_string = "tcp://" + service_hosts[0];
       }

--- a/plugins/ZmqReceiverImpl.hpp
+++ b/plugins/ZmqReceiverImpl.hpp
@@ -55,10 +55,12 @@ public:
   bool can_receive() const noexcept override { return m_socket_connected; }
   void connect_for_receives(const nlohmann::json& connection_info) override
   {
-    auto service_hosts =
-      Resolver::GetServiceAddresses(connection_info.value<std::string>("service_name", "dunedaqipm"));
-    if (service_hosts.size() > 0) {
-      m_connection_string = "tcp://" + service_hosts[0];
+    auto service_name = connection_info.value<std::string>("service_name", "");
+    if (service_name != "") {
+      auto service_hosts = Resolver::GetServiceAddresses(service_name);
+      if (service_hosts.size() > 0) {
+        m_connection_string = "tcp://" + service_hosts[0];
+      }
     }
     if (m_connection_string == "") {
       m_connection_string = connection_info.value<std::string>("connection_string", "inproc://default");

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -10,6 +10,7 @@
 #ifndef IPM_PLUGINS_ZMQSENDERIMPL_HPP_
 #define IPM_PLUGINS_ZMQSENDERIMPL_HPP_
 
+#include "ipm/Resolver.hpp"
 #include "ipm/Sender.hpp"
 #include "ipm/ZmqContext.hpp"
 
@@ -52,7 +53,14 @@ public:
   bool can_send() const noexcept override { return m_socket_connected; }
   void connect_for_sends(const nlohmann::json& connection_info)
   {
-    m_connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
+    auto service_hosts =
+      Resolver::GetServiceAddresses(connection_info.value<std::string>("service_name", "dunedaqipm"));
+    if (service_hosts.size() > 0) {
+      m_connection_string = "tcp://" + service_hosts[0];
+    }
+    if (m_connection_string == "") {
+      m_connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
+    }
     TLOG() << "Connection String is " << m_connection_string;
     try {
 

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -54,8 +54,9 @@ public:
   void connect_for_sends(const nlohmann::json& connection_info)
   {
     auto service_name = connection_info.value<std::string>("service_name", "");
+    auto host_name = connection_info.value<std::string>("host_name", "");
     if (service_name != "") {
-      auto service_hosts = GetServiceAddresses(service_name);
+      auto service_hosts = GetServiceAddresses(service_name, host_name);
       if (service_hosts.size() > 0) {
         m_connection_string = "tcp://" + service_hosts[0];
       }

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -55,7 +55,7 @@ public:
   {
     auto service_name = connection_info.value<std::string>("service_name", "");
     if (service_name != "") {
-      auto service_hosts = Resolver::GetServiceAddresses(service_name);
+      auto service_hosts = GetServiceAddresses(service_name);
       if (service_hosts.size() > 0) {
         m_connection_string = "tcp://" + service_hosts[0];
       }

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -53,10 +53,12 @@ public:
   bool can_send() const noexcept override { return m_socket_connected; }
   void connect_for_sends(const nlohmann::json& connection_info)
   {
-    auto service_hosts =
-      Resolver::GetServiceAddresses(connection_info.value<std::string>("service_name", "dunedaqipm"));
-    if (service_hosts.size() > 0) {
-      m_connection_string = "tcp://" + service_hosts[0];
+    auto service_name = connection_info.value<std::string>("service_name", "");
+    if (service_name != "") {
+      auto service_hosts = Resolver::GetServiceAddresses(service_name);
+      if (service_hosts.size() > 0) {
+        m_connection_string = "tcp://" + service_hosts[0];
+      }
     }
     if (m_connection_string == "") {
       m_connection_string = connection_info.value<std::string>("connection_string", "inproc://default");


### PR DESCRIPTION
When a Kubernetes Service has a named port, Kubernetes will automatically create a SRV record of the form "_<port name>._<protocol, e.g. tcp>.<pod name>" in its internal DNS server pointing to the internal IP and port of that named port (which could be generated by Kubernetes at runtime).

This branch adds the ability for IPM to use these records by specifying a "service_name" configuration parameter, which can be either the full SRV record name above, or, with the addition of a "host_name" parameter, generate it assuming TCP as the protocol.