### PR TITLE
Add register_callback and unregister_callback methods to ipm::Receiver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
 set(IPM_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging nlohmann_json::nlohmann_json cppzmq pthread)
 
 #daq_add_library(Receiver.cpp Sender.cpp LINK_LIBRARIES appfwk::appfwk logging::logging cppzmq)
-daq_add_library(Receiver.cpp Sender.cpp LINK_LIBRARIES ${IPM_DEPENDENCIES})
+daq_add_library(Receiver.cpp Sender.cpp CallbackAdapter.cpp LINK_LIBRARIES ${IPM_DEPENDENCIES})
 
 daq_add_plugin(ZmqSender duneIPM LINK_LIBRARIES ipm)
 daq_add_plugin(ZmqReceiver duneIPM LINK_LIBRARIES ipm)

--- a/include/ipm/Receiver.hpp
+++ b/include/ipm/Receiver.hpp
@@ -97,6 +97,9 @@ public:
 
   Response receive(const duration_t& timeout, message_size_t num_bytes = s_any_size);
 
+  virtual void register_callback(std::function<void(Response&)>) = 0;
+  virtual void unregister_callback() = 0;
+
   Receiver(const Receiver&) = delete;
   Receiver& operator=(const Receiver&) = delete;
 

--- a/plugins/ZmqReceiver.cpp
+++ b/plugins/ZmqReceiver.cpp
@@ -7,6 +7,7 @@
  * received with this code.
  */
 
+#include "CallbackAdapter.hpp"
 #include "ipm/Receiver.hpp"
 #include "ipm/ZmqContext.hpp"
 
@@ -26,6 +27,7 @@ public:
 
   ~ZmqReceiver()
   {
+    unregister_callback();
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (m_connection_string != "" && m_socket_connected) {
       try {
@@ -49,9 +51,13 @@ public:
     } catch (zmq::error_t const& err) {
       throw ZmqOperationError(ERS_HERE, "bind", "receive", err.what(), m_connection_string);
     }
+    m_callback_adapter.set_receiver(this);
   }
 
   bool can_receive() const noexcept override { return m_socket_connected; }
+
+  void register_callback(std::function<void(Response&)> callback) { m_callback_adapter.set_callback(callback); }
+  void unregister_callback() { m_callback_adapter.clear_callback(); }
 
 protected:
   Receiver::Response receive_(const duration_t& timeout) override
@@ -106,6 +112,7 @@ private:
   zmq::socket_t m_socket;
   std::string m_connection_string;
   bool m_socket_connected{ false };
+  CallbackAdapter m_callback_adapter;
 };
 } // namespace ipm
 } // namespace dunedaq

--- a/plugins/ZmqSenderImpl.hpp
+++ b/plugins/ZmqSenderImpl.hpp
@@ -70,7 +70,7 @@ public:
       m_socket_connected = true;
     } catch (zmq::error_t const& err) {
       auto operation = m_sender_type == SenderType::Push ? "connect" : "bind";
-      ers::error(ZmqOperationError(ERS_HERE, operation, "send", err.what(), m_connection_string));
+      throw ZmqOperationError(ERS_HERE, operation, "send", err.what(), m_connection_string);
     }
   }
 

--- a/plugins/ZmqSubscriber.cpp
+++ b/plugins/ZmqSubscriber.cpp
@@ -8,6 +8,7 @@
  * received with this code.
  */
 
+#include "CallbackAdapter.hpp"
 #include "ipm/Subscriber.hpp"
 #include "ipm/ZmqContext.hpp"
 
@@ -28,6 +29,7 @@ public:
 
   ~ZmqSubscriber()
   {
+    unregister_callback();
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (!m_connection_strings.empty() && m_socket_connected) {
       m_socket_connected = false;
@@ -66,6 +68,7 @@ public:
       }
     }
     m_socket_connected = true;
+    m_callback_adapter.set_receiver(this);
   }
 
   bool can_receive() const noexcept override { return m_socket_connected; }
@@ -86,6 +89,9 @@ public:
       throw ZmqUnsubscribeError(ERS_HERE, err.what(), topic);
     }
   }
+
+  void register_callback(std::function<void(Response&)> callback) { m_callback_adapter.set_callback(callback); }
+  void unregister_callback() { m_callback_adapter.clear_callback(); }
 
 protected:
   Receiver::Response receive_(const duration_t& timeout) override
@@ -138,6 +144,7 @@ private:
   zmq::socket_t m_socket;
   std::vector<std::string> m_connection_strings;
   bool m_socket_connected{ false };
+  CallbackAdapter m_callback_adapter;
 };
 } // namespace ipm
 } // namespace dunedaq

--- a/src/CallbackAdapter.cpp
+++ b/src/CallbackAdapter.cpp
@@ -1,0 +1,108 @@
+/**
+ *
+ * @file CallbackAdapter.cpp ipm CallbackAdapter class
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "CallbackAdapter.hpp"
+
+#include "logging/Logging.hpp"
+
+#include <string>
+#include <utility>
+
+namespace dunedaq::ipm {
+
+CallbackAdapter::~CallbackAdapter() noexcept
+{
+  {
+    std::lock_guard<std::mutex> lk(m_callback_mutex);
+    m_callback = nullptr;
+  }
+  shutdown();
+  m_receiver_ptr = nullptr;
+}
+
+void
+CallbackAdapter::set_receiver(Receiver* receiver_ptr)
+{
+  {
+    std::lock_guard<std::mutex> lk(m_callback_mutex);
+    m_receiver_ptr = receiver_ptr;
+  }
+
+  if (m_receiver_ptr != nullptr && m_callback != nullptr) {
+    startup();
+  }
+}
+
+void
+CallbackAdapter::set_callback(std::function<void(Receiver::Response&)> callback)
+{
+  {
+    std::lock_guard<std::mutex> lk(m_callback_mutex);
+    m_callback = callback;
+  }
+
+  if (m_receiver_ptr != nullptr && m_callback != nullptr) {
+    startup();
+  }
+}
+
+void
+CallbackAdapter::clear_callback()
+{
+  {
+    std::lock_guard<std::mutex> lk(m_callback_mutex);
+    m_callback = nullptr;
+  }
+  shutdown();
+}
+
+void
+CallbackAdapter::shutdown()
+{
+  if (m_thread && m_thread->joinable())
+    m_thread->join();
+
+  m_is_listening = false;
+  m_thread.reset(nullptr);
+}
+
+void
+CallbackAdapter::startup()
+{
+  shutdown();
+  m_is_listening = false;
+  m_thread.reset(new std::thread([&] { thread_loop(); }));
+
+  while (!m_is_listening.load()) {
+    usleep(1000);
+  }
+}
+
+void
+CallbackAdapter::thread_loop()
+{
+  do {
+    try {
+      auto response = m_receiver_ptr->receive(Receiver::s_no_block);
+
+      TLOG_DEBUG(25) << "Received " << response.data.size() << " bytes. Dispatching to callback.";
+      {
+        std::lock_guard<std::mutex> lk(m_callback_mutex);
+        if (m_callback != nullptr) {
+          m_callback(response);
+        }
+      }
+    } catch (ipm::ReceiveTimeoutExpired const& tmo) {
+      usleep(10000);
+    }
+    m_is_listening = true;
+  } while (m_callback != nullptr && m_receiver_ptr != nullptr);
+}
+
+} // namespace dunedaq::ipm

--- a/src/CallbackAdapter.hpp
+++ b/src/CallbackAdapter.hpp
@@ -1,0 +1,49 @@
+/**
+ *
+ * @file CallbackAdapter.hpp IPM CallbackAdapter class
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef IPM_SRC_CALLBACKADAPTER_HPP_
+#define IPM_SRC_CALLBACKADAPTER_HPP_
+
+#include "ipm/Receiver.hpp"
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+namespace dunedaq {
+namespace ipm {
+
+class CallbackAdapter
+{
+public:
+  CallbackAdapter() = default; // Explicitly defaulted
+
+  virtual ~CallbackAdapter() noexcept;
+
+  void set_receiver(Receiver* receiver_ptr);
+  void set_callback(std::function<void(Receiver::Response&)> callback);
+  void clear_callback();
+
+private:
+  void startup();
+  void shutdown();
+  void thread_loop();
+
+  Receiver* m_receiver_ptr{ nullptr };
+  std::function<void(Receiver::Response&)> m_callback{ nullptr };
+  mutable std::mutex m_callback_mutex;
+  std::unique_ptr<std::thread> m_thread{ nullptr };
+  std::atomic<bool> m_is_listening{ false };
+};
+} // namespace ipm
+} // namespace dunedaq
+
+#endif // IPM_SRC_CALLBACKADAPTER_HPP_

--- a/unittest/ZmqSendReceive_test.cxx
+++ b/unittest/ZmqSendReceive_test.cxx
@@ -48,4 +48,55 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
   BOOST_REQUIRE_EQUAL(response.data[3], 'T');
 }
 
+BOOST_AUTO_TEST_CASE(CallbackTest)
+{
+
+  auto the_receiver = make_ipm_receiver("ZmqReceiver");
+  BOOST_REQUIRE(the_receiver != nullptr);
+  BOOST_REQUIRE(!the_receiver->can_receive());
+
+  auto the_sender = make_ipm_sender("ZmqSender");
+  BOOST_REQUIRE(the_sender != nullptr);
+  BOOST_REQUIRE(!the_sender->can_send());
+
+  nlohmann::json empty_json = nlohmann::json::object();
+  the_receiver->connect_for_receives(empty_json);
+  the_sender->connect_for_sends(empty_json);
+
+  BOOST_REQUIRE(the_receiver->can_receive());
+  BOOST_REQUIRE(the_sender->can_send());
+
+  std::vector<char> test_data{ 'T', 'E', 'S', 'T' };
+  std::atomic<bool> message_received = false;
+
+  auto callback_fun = [&](Receiver::Response& res) {
+    BOOST_REQUIRE_EQUAL(res.data.size(), test_data.size());
+    for (size_t ii = 0; ii < res.data.size(); ++ii) {
+      BOOST_REQUIRE_EQUAL(res.data[ii], test_data[ii]);
+    }
+    message_received = true;
+  };
+  the_receiver->register_callback(callback_fun);
+
+  the_sender->send(test_data.data(), test_data.size(), Sender::s_no_block);
+  while (!message_received.load()) {
+    usleep(15000);
+  }
+
+  message_received = false;
+  test_data = { 'A', 'N', 'O', 'T', 'H', 'E', 'R', ' ', 'T', 'E', 'S', 'T' };
+  the_sender->send(test_data.data(), test_data.size(), Sender::s_no_block);
+  while (!message_received.load()) {
+    usleep(15000);
+  }
+
+  message_received = false;
+  test_data = { 'A', ' ', 'T', 'H', 'I', 'R', 'D', ' ', 'T', 'E', 'S', 'T' };
+  the_receiver->unregister_callback();
+  the_sender->send(test_data.data(), test_data.size(), Sender::s_no_block);
+
+  usleep(100000);
+  BOOST_REQUIRE_EQUAL(message_received, false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
... API (thus also ipm::Subscriber). Add CallbackAdapter class which enables callback use for non-callback-supporting transports (such as ZMQ)