### PR TITLE
Introduce setting of number of IO threads to ZmqContext, via

### DIFF
--- a/include/ipm/ZmqContext.hpp
+++ b/include/ipm/ZmqContext.hpp
@@ -92,8 +92,19 @@ public:
 
   zmq::context_t& GetContext() { return m_context; }
 
+  void set_context_threads(int nthreads) { m_context.set(zmq::ctxopt::io_threads, nthreads); }
+
 private:
-  ZmqContext() {}
+  ZmqContext()
+  {
+    auto threads_c = getenv("IPM_ZMQ_IO_THREADS");
+    if (threads_c != nullptr) {
+      auto threads = std::atoi(threads_c);
+      if (threads > 1) {
+        set_context_threads(threads);
+      }
+    }
+  }
   ~ZmqContext() { m_context.close(); }
   zmq::context_t m_context;
 

--- a/test/apps/zmq_recv.cpp
+++ b/test/apps/zmq_recv.cpp
@@ -31,8 +31,7 @@ int main(int argc, char* argv[]){
   }
 
   if (nthreads > 1) {
-    zmq::context_t& context = dunedaq::ipm::ZmqContext::instance().GetContext();
-    context.set(zmq::ctxopt::io_threads, nthreads);
+    dunedaq::ipm::ZmqContext::instance().set_context_threads(nthreads);
   }
 
   // Receiver side

--- a/test/apps/zmq_send.cpp
+++ b/test/apps/zmq_send.cpp
@@ -32,8 +32,7 @@ int main(int argc, char* argv[]){
   }
 
   if (nthreads > 1) {
-    zmq::context_t& context = dunedaq::ipm::ZmqContext::instance().GetContext();
-    context.set(zmq::ctxopt::io_threads, nthreads);
+    dunedaq::ipm::ZmqContext::instance().set_context_threads(nthreads);
   }
  
   std::shared_ptr<dunedaq::ipm::Sender> sender=dunedaq::ipm::make_ipm_sender("ZmqSender");

--- a/test/apps/zmq_send.cpp
+++ b/test/apps/zmq_send.cpp
@@ -31,9 +31,10 @@ int main(int argc, char* argv[]){
     return 0;
   }
 
-
-  zmq::context_t& context=dunedaq::ipm::ZmqContext::instance().GetContext();
-  context.set(zmq::ctxopt::io_threads, nthreads);
+  if (nthreads > 1) {
+    zmq::context_t& context = dunedaq::ipm::ZmqContext::instance().GetContext();
+    context.set(zmq::ctxopt::io_threads, nthreads);
+  }
  
   std::shared_ptr<dunedaq::ipm::Sender> sender=dunedaq::ipm::make_ipm_sender("ZmqSender");
   sender->connect_for_sends({ {"connection_string", conString} });


### PR DESCRIPTION
IPM_ZMQ_IO_THREADS environment variable. Update zmq_send and zmq_recv tests to only set number if specified on command line.