### PR TITLE
Extend unit test coverage by checking for exceptions from bad connection

### DIFF
--- a/unittest/ZmqPublisher_test.cxx
+++ b/unittest/ZmqPublisher_test.cxx
@@ -7,10 +7,12 @@
  */
 
 #include "ipm/Sender.hpp"
+#include "ipm/ZmqContext.hpp"
 
 #define BOOST_TEST_MODULE ZmqPublisher_test // NOLINT
 
 #include "boost/test/unit_test.hpp"
+#include "nlohmann/json.hpp"
 
 #include <string>
 #include <vector>
@@ -23,6 +25,33 @@ BOOST_AUTO_TEST_CASE(BasicTests)
 {
   auto the_sender = make_ipm_sender("ZmqPublisher");
   BOOST_REQUIRE(the_sender != nullptr);
+  BOOST_REQUIRE(!the_sender->can_send());
+}
+
+BOOST_AUTO_TEST_CASE(Errors)
+{
+  auto the_sender = make_ipm_sender("ZmqPublisher");
+  BOOST_REQUIRE(the_sender != nullptr);
+  BOOST_REQUIRE(!the_sender->can_send());
+
+  nlohmann::json config_json;
+
+  config_json["connection_string"] = "not a uri";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("invalid URI") != std::string::npos;
+  });
+  BOOST_REQUIRE(!the_sender->can_send());
+
+  config_json["connection_string"] = "tcp://thishostddoesnotexist";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("Unable to resolve connection_string") != std::string::npos;
+  });
+  BOOST_REQUIRE(!the_sender->can_send());
+
+  config_json["connection_string"] = "badproto://default";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("while calling bind on the ZMQ send socket") != std::string::npos;
+  });
   BOOST_REQUIRE(!the_sender->can_send());
 }
 

--- a/unittest/ZmqReceiver_test.cxx
+++ b/unittest/ZmqReceiver_test.cxx
@@ -30,20 +30,34 @@ BOOST_AUTO_TEST_CASE(BasicTests)
 
 BOOST_AUTO_TEST_CASE(Subscribe)
 {
-
   auto the_receiver = make_ipm_subscriber("ZmqReceiver");
   BOOST_REQUIRE(the_receiver == nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(Exceptions)
+BOOST_AUTO_TEST_CASE(Errors)
 {
   auto the_receiver = make_ipm_receiver("ZmqReceiver");
   BOOST_REQUIRE(the_receiver != nullptr);
+  BOOST_REQUIRE(!the_receiver->can_receive());
 
   nlohmann::json config_json;
-  config_json["connection_string"] = "invalid_connection_string";
-  BOOST_REQUIRE_EXCEPTION(
-    the_receiver->connect_for_receives(config_json), ZmqOperationError, [&](ZmqOperationError const&) { return true; });
-}
 
+  config_json["connection_string"] = "not a uri";
+  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("invalid URI") != std::string::npos;
+  });
+  BOOST_REQUIRE(!the_receiver->can_receive());
+
+  config_json["connection_string"] = "tcp://thishostddoesnotexist";
+  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("Unable to resolve connection_string") != std::string::npos;
+  });
+  BOOST_REQUIRE(!the_receiver->can_receive());
+
+  config_json["connection_string"] = "badproto://default";
+  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("while calling bind on the ZMQ receive socket") != std::string::npos;
+  });
+  BOOST_REQUIRE(!the_receiver->can_receive());
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/ZmqSender_test.cxx
+++ b/unittest/ZmqSender_test.cxx
@@ -27,15 +27,30 @@ BOOST_AUTO_TEST_CASE(BasicTests)
   BOOST_REQUIRE(!the_sender->can_send());
 }
 
-BOOST_AUTO_TEST_CASE(Exceptions)
+BOOST_AUTO_TEST_CASE(Errors)
 {
   auto the_sender = make_ipm_sender("ZmqSender");
   BOOST_REQUIRE(the_sender != nullptr);
+  BOOST_REQUIRE(!the_sender->can_send());
 
   nlohmann::json config_json;
-  config_json["connection_string"] = "invalid_connection_string";
-  BOOST_REQUIRE_EXCEPTION(
-    the_sender->connect_for_sends(config_json), ZmqOperationError, [](const ZmqOperationError&) { return true; });
+
+  config_json["connection_string"] = "not a uri";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("Operation failed for all resolved connection strings") != std::string::npos;
+  });
+  BOOST_REQUIRE(!the_sender->can_send());
+  
+  config_json["connection_string"] = "tcp://thishostddoesnotexist";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("Operation failed for all resolved connection strings") != std::string::npos;
+  });
+  BOOST_REQUIRE(!the_sender->can_send());
+  
+  config_json["connection_string"] = "badproto://default";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+    return std::string(e.what()).find("Operation failed for all resolved connection strings") != std::string::npos;
+  });
   BOOST_REQUIRE(!the_sender->can_send());
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/ZmqSubscriber_test.cxx
+++ b/unittest/ZmqSubscriber_test.cxx
@@ -7,6 +7,7 @@
  */
 
 #include "ipm/Subscriber.hpp"
+#include "ipm/ZmqContext.hpp"
 
 #define BOOST_TEST_MODULE ZmqSubscriber_test // NOLINT
 
@@ -27,6 +28,27 @@ BOOST_AUTO_TEST_CASE(BasicTests)
 
   auto the_receiver = make_ipm_receiver("ZmqSubscriber");
   BOOST_REQUIRE(the_receiver != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Errors)
+{
+  auto the_subscriber = make_ipm_subscriber("ZmqSubscriber");
+  BOOST_REQUIRE(the_subscriber != nullptr);
+  BOOST_REQUIRE(!the_subscriber->can_receive());
+
+  nlohmann::json config_json;
+
+  config_json["connection_string"] = "not a uri";
+  the_subscriber->connect_for_receives(config_json);
+  BOOST_REQUIRE(the_subscriber->can_receive());
+
+  config_json["connection_string"] = "tcp://thishostddoesnotexist";
+  the_subscriber->connect_for_receives(config_json);
+  BOOST_REQUIRE(the_subscriber->can_receive());
+
+  config_json["connection_string"] = "badproto://default";
+  the_subscriber->connect_for_receives(config_json);
+  BOOST_REQUIRE(the_subscriber->can_receive());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
strings while calling connect_for_*.