### PR TITLE
Initialize m_socket_connected to false. Fixes ZmqPublisher_test

### DIFF
--- a/plugins/ZmqPublisher.cpp
+++ b/plugins/ZmqPublisher.cpp
@@ -153,7 +153,7 @@ protected:
 private:
   zmq::socket_t m_socket;
   std::string m_connection_string;
-  bool m_socket_connected;
+  bool m_socket_connected{ false };
 };
 
 } // namespace dunedaq::ipm


### PR DESCRIPTION
# Description

After merging enhanced unit tests for the `ipm` package, I noticed that `ZmqPublisher_test` was failing. The reason for this is that ZmqPublisher was not initializing its `m_socket_connected` parameter, unlike all of the other Zmq plugins.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

This change can be seen by running  the ZmqPublisher_test with and without the change. It is unknown whether the issue has cropped up elsewhere.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

