### PR TITLE
Wait for outstanding sends in ZmqSender and ZmqPublisher destructors.

### DIFF
--- a/include/ipm/ZmqContext.hpp
+++ b/include/ipm/ZmqContext.hpp
@@ -21,6 +21,7 @@ enum
   TLVL_ZMQPUBLISHER_SEND_START = 12,
   TLVL_ZMQPUBLISHER_SEND_ERR = 2,
   TLVL_ZMQPUBLISHER_SEND_END = 13,
+  TLVL_ZMQPUBLISHER_DESTRUCTOR = 5,
   TLVL_ZMQRECEIVER_RECV_HDR = 14,
   TLVL_ZMQRECEIVER_RECV_HDR_2 = 15,
   TLVL_ZMQRECEIVER_RECV_DATA = 16,
@@ -29,6 +30,7 @@ enum
   TLVL_ZMQSENDER_SEND_START = 19,
   TLVL_ZMQSENDER_SEND_ERR = 3,
   TLVL_ZMQSENDER_SEND_END = 20,
+  TLVL_ZMQSENDER_DESTRUCTOR = 5,
   TLVL_ZMQSUBSCRIBER_RECV_HDR = 21,
   TLVL_ZMQSUBSCRIBER_RECV_HDR_2 = 22,
   TLVL_ZMQSUBSCRIBER_RECV_DATA = 23,
@@ -150,7 +152,11 @@ private:
       set_context_maxsockets(s_minimum_sockets);
     }
   }
-  ~ZmqContext() { m_context.close(); }
+  ~ZmqContext() { 
+      TLOG_DEBUG(TLVL_ZMQCONTEXT) << "Closing ZMQ Context";
+      m_context.close();
+      TLOG_DEBUG(TLVL_ZMQCONTEXT) << "ZMQ Context closed";
+  }
   zmq::context_t m_context;
   static constexpr int s_minimum_sockets = 16636;
 

--- a/plugins/ZmqPublisher.cpp
+++ b/plugins/ZmqPublisher.cpp
@@ -31,6 +31,20 @@ public:
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (m_connection_string != "" && m_socket_connected) {
       try {
+        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << "Setting socket HWM to zero";
+        m_socket.set(zmq::sockopt::sndhwm, 1);
+
+        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << "Waiting up to 10s for socket to become writable before disconnecting";
+        auto start_time = std::chrono::steady_clock::now();
+        while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() < 10000) {
+          auto events = m_socket.get(zmq::sockopt::events);
+          if ((events & ZMQ_POLLOUT) != 0) {
+            break;
+          }
+          usleep(1000);
+        }
+        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << "Disconnecting socket from " << m_connection_string;
+
         m_socket.unbind(m_connection_string);
         m_socket_connected = false;
       } catch (zmq::error_t const& err) {

--- a/plugins/ZmqSender.cpp
+++ b/plugins/ZmqSender.cpp
@@ -30,6 +30,24 @@ public:
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (m_connection_string != "" && m_socket_connected) {
       try {
+        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << "Setting socket HWM to zero";
+        m_socket.set(zmq::sockopt::sndhwm, 1);
+
+        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR)
+          << "Waiting up to 10s for socket to become writable before disconnecting";
+        auto start_time = std::chrono::steady_clock::now();
+        while (
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() <
+          10000) {
+          auto events = m_socket.get(zmq::sockopt::events);
+          if ((events & ZMQ_POLLOUT) != 0) {
+            break;
+          }
+          usleep(1000);
+        }
+        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << "Disconnecting socket from " << m_connection_string;
+
+
         m_socket.disconnect(m_connection_string);
         m_socket_connected = false;
       } catch (zmq::error_t const& err) {

--- a/test/apps/zmq_send.cpp
+++ b/test/apps/zmq_send.cpp
@@ -98,6 +98,4 @@ main(int argc, char* argv[])
   auto nano = std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count();
   auto bw = (packetSize * npackets) / static_cast<double>(nano);
   TLOG() << "Sent " << packetSize * npackets << " bytes in " << nano << " ns " << bw << " GB/s";
-  TLOG() << "Sleep 2 to allow finish???";
-  sleep(2); // Sleep for 2
 }


### PR DESCRIPTION
# Description

Resolves #107 

Adds a wait time in ZmqSender destructor for any outstanding sends to be resolved. Can be tested using `zmq_recv -p 10000 & zmq_send -p 10000 -s 1024000`, as described in the Issue.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
