### PR TITLE
Configure connection name in ipm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(utilities REQUIRED)
 find_package(cetlib REQUIRED)
 find_package(cppzmq REQUIRED)
 find_package(ers REQUIRED)
-find_package(nlohmann_json REQUIRED)
 find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
 find_package(opmonlib REQUIRED)
 

--- a/cmake/ipmConfig.cmake.in
+++ b/cmake/ipmConfig.cmake.in
@@ -5,7 +5,6 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(ers)
 find_dependency(cetlib)
-find_dependency(nlohmann_json)
 find_dependency(cppzmq)
 find_dependency(logging)
 find_dependency(utilities)

--- a/include/ipm/Receiver.hpp
+++ b/include/ipm/Receiver.hpp
@@ -27,7 +27,6 @@
 #include "cetlib/compiler_macros.h"
 #include "ers/Issue.hpp"
 #include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
-#include "nlohmann/json.hpp"
 #include "opmonlib/MonitorableObject.hpp"
 
 #include <atomic>
@@ -40,12 +39,12 @@ namespace dunedaq {
 ERS_DECLARE_ISSUE(ipm, KnownStateForbidsReceive, "Receiver not in a state to receive data", )
 ERS_DECLARE_ISSUE(ipm,
                   UnexpectedNumberOfBytes,
-                  "Expected " << bytes1 << " bytes in message but received " << bytes2,
-                  ((int)bytes1)((int)bytes2)) // NOLINT
+                  connection_name << ": Expected " << bytes1 << " bytes in message but received " << bytes2,
+                  ((std::string)connection_name)((int)bytes1)((int)bytes2)) // NOLINT
 ERS_DECLARE_ISSUE(ipm,
                   ReceiveTimeoutExpired,
-                  "Unable to receive within timeout period (timeout period was " << timeout << " milliseconds)",
-                  ((int)timeout)) // NOLINT
+                  connection_name << ": Unable to receive within timeout period (timeout period was " << timeout << " milliseconds)",
+                  ((std::string)connection_name)((int)timeout)) // NOLINT
 // Reenable coverage collection LCOV_EXCL_STOP
 } // namespace dunedaq
 
@@ -75,6 +74,12 @@ class Receiver : public opmonlib::MonitorableObject
 {
 
 public:
+    struct ConnectionInfo
+    {
+      std::string connection_name{ "" };
+      std::string connection_string{ "" };
+      std::vector<std::string> connection_strings{};
+    };
   using duration_t = std::chrono::milliseconds;
   static constexpr duration_t s_block = duration_t::max();
   static constexpr duration_t s_no_block = duration_t::zero();
@@ -86,7 +91,7 @@ public:
   Receiver() = default;
   virtual ~Receiver() = default;
 
-  virtual std::string connect_for_receives(const nlohmann::json& connection_info) = 0;
+  virtual std::string connect_for_receives(const ConnectionInfo& connection_info) = 0;
 
   virtual bool can_receive() const noexcept = 0;
 
@@ -113,6 +118,7 @@ public:
   Receiver& operator=(Receiver&&) = delete;
 
 protected:
+  ConnectionInfo m_connection_info;
   void generate_opmon_data() override;
 
   virtual Response receive_(const duration_t& timeout, bool no_tmoexcept_mode) = 0;

--- a/include/ipm/Sender.hpp
+++ b/include/ipm/Sender.hpp
@@ -43,8 +43,8 @@ ERS_DECLARE_ISSUE(ipm,
                   ((std::string)connection_name))
 ERS_DECLARE_ISSUE(ipm,
                   SendTimeoutExpired,
-                  "Unable to send within timeout period (timeout period was " << timeout << " milliseconds)",
-                  ((int)timeout)) // NOLINT
+                  connection_name << ": Unable to send within timeout period (timeout period was " << timeout << " milliseconds)",
+                  ((std::string)connection_name)((int)timeout)) // NOLINT
 
 // Reenable coverage collection LCOV_EXCL_STOP
 } // namespace dunedaq

--- a/include/ipm/Sender.hpp
+++ b/include/ipm/Sender.hpp
@@ -27,7 +27,6 @@
 #include "cetlib/compiler_macros.h"
 #include "ers/Issue.hpp"
 #include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
-#include "nlohmann/json.hpp"
 #include "opmonlib/MonitorableObject.hpp"
 
 #include <atomic>
@@ -38,7 +37,10 @@
 namespace dunedaq {
 // Disable coverage collection LCOV_EXCL_START
 ERS_DECLARE_ISSUE(ipm, KnownStateForbidsSend, "Sender not in a state to send data", )
-ERS_DECLARE_ISSUE(ipm, NullPointerPassedToSend, "An null pointer to memory was passed to Sender::send", )
+ERS_DECLARE_ISSUE(ipm,
+                  NullPointerPassedToSend,
+                  connection_name << ": An null pointer to memory was passed to Sender::send",
+                  ((std::string)connection_name))
 ERS_DECLARE_ISSUE(ipm,
                   SendTimeoutExpired,
                   "Unable to send within timeout period (timeout period was " << timeout << " milliseconds)",
@@ -73,6 +75,12 @@ class Sender : public opmonlib::MonitorableObject
 {
 
 public:
+  struct ConnectionInfo
+  {
+    std::string connection_name{ "" };
+    std::string connection_string{ "inproc://default" };
+    int capacity{ 0 };
+  };
   using duration_t = std::chrono::milliseconds;
   static constexpr duration_t s_block = duration_t::max();
   static constexpr duration_t s_no_block = duration_t::zero();
@@ -82,7 +90,7 @@ public:
   Sender() = default;
   virtual ~Sender() = default;
 
-  virtual std::string connect_for_sends(const nlohmann::json& connection_info) = 0;
+  virtual std::string connect_for_sends(const ConnectionInfo& connection_info) = 0;
 
   virtual bool can_send() const noexcept = 0;
 
@@ -104,6 +112,7 @@ public:
   Sender& operator=(Sender&&) = delete;
 
 protected:
+  ConnectionInfo m_connection_info;
   void generate_opmon_data() override;
 
   virtual bool send_(const void* message,

--- a/include/ipm/Subscriber.hpp
+++ b/include/ipm/Subscriber.hpp
@@ -31,7 +31,6 @@
 #include "cetlib/BasicPluginFactory.h"
 #include "cetlib/compiler_macros.h"
 #include "ers/Issue.hpp"
-#include "nlohmann/json.hpp"
 
 #include <memory>
 #include <string>

--- a/include/ipm/ZmqContext.hpp
+++ b/include/ipm/ZmqContext.hpp
@@ -50,9 +50,9 @@ namespace dunedaq {
  */
 ERS_DECLARE_ISSUE(ipm,
                   ZmqOperationError,
-                  "An exception occured while calling " << operation << " on the ZMQ " << direction << " socket: "
-                                                        << what << " (connection_string: " << connection_string << ")",
-                  ((std::string)operation)((std::string)direction)((const char*)what)(
+                  connection_name << ": An exception occured while calling " << operation << " on the ZMQ " << direction
+                                  << " socket: " << what << " (connection_string: " << connection_string << ")",
+                  ((std::string)connection_name)((std::string)operation)((std::string)direction)((const char*)what)(
                     (std::string)connection_string)) // NOLINT
                                                      /// @endcond LCOV_EXCL_STOP
 
@@ -63,11 +63,12 @@ ERS_DECLARE_ISSUE(ipm,
  * @param topic Send topic
  * @cond Doxygen doesn't like ERS macros LCOV_EXCL_START
  */
-ERS_DECLARE_ISSUE(ipm,
-                  ZmqSendError,
-                  "An exception occurred while sending " << N << " bytes to " << topic << ": " << what,
-                  ((const char*)what)((int)N)((std::string)topic)) // NOLINT
-                                                                   /// @endcond LCOV_EXCL_STOP
+ERS_DECLARE_ISSUE(
+  ipm,
+  ZmqSendError,
+  connection_name << ": An exception occurred while sending " << N << " bytes to " << topic << ": " << what,
+  ((std::string)connection_name)((const char*)what)((int)N)((std::string)topic)) // NOLINT
+                                                                                 /// @endcond LCOV_EXCL_STOP
 
 /**
  * @brief An ERS Error indicating that an exception was thrown from ZMQ while receiving
@@ -77,9 +78,9 @@ ERS_DECLARE_ISSUE(ipm,
  */
 ERS_DECLARE_ISSUE(ipm,
                   ZmqReceiveError,
-                  "An exception occured while receiving " << which << ": " << what,
-                  ((const char*)what)((const char*)which)) // NOLINT
-                                                           /// @endcond LCOV_EXCL_STOP
+                  connection_name << ": An exception occured while receiving " << which << ": " << what,
+                  ((std::string)connection_name)((const char*)what)((const char*)which)) // NOLINT
+                                                                                         /// @endcond LCOV_EXCL_STOP
 
 /**
  * @brief An ERS Error indicating that an exception was thrown from ZMQ during a subscribe
@@ -89,8 +90,8 @@ ERS_DECLARE_ISSUE(ipm,
  */
 ERS_DECLARE_ISSUE(ipm,
                   ZmqSubscribeError,
-                  "An execption occured while subscribing to " << topic << ": " << what,
-                  ((const char*)what)((std::string)topic)) // NOLINT
+                  connection_name << ": An execption occured while subscribing to " << topic << ": " << what,
+                  ((std::string)connection_name)((const char*)what)((std::string)topic)) // NOLINT
 /// @endcond LCOV_EXCL_STOP
 
 /**
@@ -101,8 +102,8 @@ ERS_DECLARE_ISSUE(ipm,
  */
 ERS_DECLARE_ISSUE(ipm,
                   ZmqUnsubscribeError,
-                  "An execption occured while unsubscribing from " << topic << ": " << what,
-                  ((const char*)what)((std::string)topic)) // NOLINT
+                  connection_name << ": An execption occured while unsubscribing from " << topic << ": " << what,
+                  ((std::string)connection_name)((const char*)what)((std::string)topic)) // NOLINT
 /// @endcond LCOV_EXCL_STOP
 
 namespace ipm {
@@ -152,10 +153,11 @@ private:
       set_context_maxsockets(s_minimum_sockets);
     }
   }
-  ~ZmqContext() { 
-      TLOG_DEBUG(TLVL_ZMQCONTEXT) << "Closing ZMQ Context";
-      m_context.close();
-      TLOG_DEBUG(TLVL_ZMQCONTEXT) << "ZMQ Context closed";
+  ~ZmqContext()
+  {
+    TLOG_DEBUG(TLVL_ZMQCONTEXT) << "Closing ZMQ Context";
+    m_context.close();
+    TLOG_DEBUG(TLVL_ZMQCONTEXT) << "ZMQ Context closed";
   }
   zmq::context_t m_context;
   static constexpr int s_minimum_sockets = 16636;

--- a/plugins/ZmqPublisher.cpp
+++ b/plugins/ZmqPublisher.cpp
@@ -29,93 +29,115 @@ public:
   ~ZmqPublisher()
   {
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
-    if (m_connection_string != "" && m_socket_connected) {
+    if (m_connection_info.connection_string != "" && m_socket_connected) {
       try {
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << "Setting socket HWM to zero";
+        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << m_connection_info.connection_name << ": Setting socket HWM to zero";
         m_socket.set(zmq::sockopt::sndhwm, 1);
 
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << "Waiting up to 10s for socket to become writable before disconnecting";
+        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR)
+          << m_connection_info.connection_name
+          << ": Waiting up to 10s for socket to become writable before disconnecting";
         auto start_time = std::chrono::steady_clock::now();
-        while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() < 10000) {
+        while (
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() <
+          10000) {
           auto events = m_socket.get(zmq::sockopt::events);
           if ((events & ZMQ_POLLOUT) != 0) {
             break;
           }
           usleep(1000);
         }
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << "Disconnecting socket from " << m_connection_string;
+        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR)
+          << m_connection_info.connection_name << ": Disconnecting socket from " << m_connection_info.connection_string;
 
-        m_socket.unbind(m_connection_string);
+        m_socket.unbind(m_connection_info.connection_string);
         m_socket_connected = false;
       } catch (zmq::error_t const& err) {
-        ers::error(ZmqOperationError(ERS_HERE, "unbind", "send", err.what(), m_connection_string));
+        ers::error(ZmqOperationError(ERS_HERE,
+                                     m_connection_info.connection_name,
+                                     "unbind",
+                                     "send",
+                                     err.what(),
+                                     m_connection_info.connection_string));
       }
     }
     m_socket.close();
   }
 
   bool can_send() const noexcept override { return m_socket_connected; }
-  std::string connect_for_sends(const nlohmann::json& connection_info) override
+  std::string connect_for_sends(const ConnectionInfo& connection_info) override
   {
+    m_connection_info = connection_info;
     try {
       m_socket.set(zmq::sockopt::sndtimeo, 0); // Return immediately if we can't send
     } catch (zmq::error_t const& err) {
       throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
                               "set timeout",
                               "send",
                               err.what(),
-                              connection_info.value<std::string>("connection_string", "inproc://default"));
+                              m_connection_info.connection_string);
     }
 
-    auto hwm = connection_info.value<int>("capacity", 0);
+    auto hwm = connection_info.capacity;
     if (hwm > 0) {
       try {
         m_socket.set(zmq::sockopt::sndhwm, hwm);
       } catch (zmq::error_t const& err) {
         throw ZmqOperationError(ERS_HERE,
+                                m_connection_info.connection_name,
                                 "set hwm",
                                 "send",
                                 err.what(),
-                                connection_info.value<std::string>("connection_string", "inproc://default"));
+                                m_connection_info.connection_string);
       }
     }
 
     std::vector<std::string> resolved;
     try {
-      utilities::ZmqUri this_uri(connection_info.value<std::string>("connection_string", "inproc://default"));
+      utilities::ZmqUri this_uri(m_connection_info.connection_string);
       resolved = this_uri.get_uri_ip_addresses();
     } catch (utilities::InvalidUri const& err) {
       throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
                               "resolve connection_string",
                               "send",
                               "An invalid URI was passed",
-                              connection_info.value<std::string>("connection_string", "inproc://default"),
+                              m_connection_info.connection_string,
                               err);
     }
 
     if (resolved.size() == 0) {
       throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
                               "resolve connection_string",
                               "send",
                               "Unable to resolve connection_string",
-                              connection_info.value<std::string>("connection_string", "inproc://default"));
+                              m_connection_info.connection_string);
     }
     for (auto& connection_string : resolved) {
-      TLOG_DEBUG(TLVL_CONNECTIONSTRING) << "Connection String is " << connection_string;
+      TLOG_DEBUG(TLVL_CONNECTIONSTRING) << m_connection_info.connection_name << ": Connection String is "
+                                        << connection_string;
       try {
         m_socket.bind(connection_string);
-        m_connection_string = m_socket.get(zmq::sockopt::last_endpoint);
+        m_connection_info.connection_string = m_socket.get(zmq::sockopt::last_endpoint);
         m_socket_connected = true;
         break;
       } catch (zmq::error_t const& err) {
-        ers::error(ZmqOperationError(ERS_HERE, "bind", "send", err.what(), connection_string));
+        ers::error(ZmqOperationError(
+          ERS_HERE, m_connection_info.connection_name, "bind", "send", err.what(), connection_string));
       }
     }
     if (!m_socket_connected) {
-      throw ZmqOperationError(ERS_HERE, "bind", "send", "Bind failed for all resolved connection strings", "");
+      throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
+                              "bind",
+                              "send",
+                              "Bind failed for all resolved connection strings",
+                              "");
     }
 
-    return m_connection_string;
+    return m_connection_info.connection_string;
   }
 
 protected:
@@ -126,7 +148,7 @@ protected:
              bool no_tmoexcept_mode) override
   {
     TLOG_DEBUG(TLVL_ZMQPUBLISHER_SEND_START)
-      << "Endpoint " << m_connection_string << ": Starting send of " << N << " bytes";
+      << m_connection_info.connection_name << ": Starting send of " << N << " bytes";
     auto start_time = std::chrono::steady_clock::now();
     zmq::send_result_t res{};
     do {
@@ -135,11 +157,11 @@ protected:
       try {
         res = m_socket.send(topic_msg, zmq::send_flags::sndmore);
       } catch (zmq::error_t const& err) {
-        throw ZmqSendError(ERS_HERE, err.what(), topic.size(), topic);
+        throw ZmqSendError(ERS_HERE, m_connection_info.connection_name, err.what(), topic.size(), topic);
       }
 
       if (!res || res != topic.size()) {
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_SEND_ERR) << "Endpoint " << m_connection_string << ": Unable to send message";
+        TLOG_DEBUG(TLVL_ZMQPUBLISHER_SEND_ERR) << m_connection_info.connection_name << ": Unable to send message";
         continue;
       }
 
@@ -147,7 +169,7 @@ protected:
       try {
         res = m_socket.send(msg, zmq::send_flags::none);
       } catch (zmq::error_t const& err) {
-        throw ZmqSendError(ERS_HERE, err.what(), N, topic);
+        throw ZmqSendError(ERS_HERE, m_connection_info.connection_name, err.what(), N, topic);
       }
 
       if (!res && timeout > duration_t::zero()) {
@@ -156,17 +178,16 @@ protected:
     } while (std::chrono::duration_cast<duration_t>(std::chrono::steady_clock::now() - start_time) < timeout && !res);
 
     if (!res && !no_tmoexcept_mode) {
-      throw SendTimeoutExpired(ERS_HERE, timeout.count());
+      throw SendTimeoutExpired(ERS_HERE, m_connection_info.connection_name, timeout.count());
     }
 
     TLOG_DEBUG(TLVL_ZMQPUBLISHER_SEND_END)
-      << "Endpoint " << m_connection_string << ": Completed send of " << N << " bytes";
+      << m_connection_info.connection_name << ": Completed send of " << N << " bytes";
     return res && res == N;
   }
 
 private:
   zmq::socket_t m_socket;
-  std::string m_connection_string;
   bool m_socket_connected{ false };
 };
 

--- a/plugins/ZmqReceiver.cpp
+++ b/plugins/ZmqReceiver.cpp
@@ -31,77 +31,92 @@ public:
   {
     unregister_callback();
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
-    if (m_connection_string != "" && m_socket_connected) {
+    if (m_connection_info.connection_string != "" && m_socket_connected) {
       try {
-        m_socket.unbind(m_connection_string);
+        m_socket.unbind(m_connection_info.connection_string);
         m_socket_connected = false;
       } catch (zmq::error_t const& err) {
-        ers::error(ZmqOperationError(ERS_HERE, "unbind", "receive", err.what(), m_connection_string));
+        ers::error(ZmqOperationError(ERS_HERE,
+                                     m_connection_info.connection_name,
+                                     "unbind",
+                                     "receive",
+                                     err.what(),
+                                     m_connection_info.connection_string));
       }
     }
     m_socket.close();
   }
 
-  std::string connect_for_receives(const nlohmann::json& connection_info) override
+  std::string connect_for_receives(const ConnectionInfo& connection_info) override
   {
+    m_connection_info = connection_info;
     try {
       m_socket.set(zmq::sockopt::rcvtimeo, 0); // Return immediately if we can't receive
     } catch (zmq::error_t const& err) {
-      throw ZmqOperationError(ERS_HERE,
+      throw ZmqOperationError(ERS_HERE, m_connection_info.connection_name,
                               "set timeout",
                               "receive",
                               err.what(),
-                              connection_info.value<std::string>("connection_string", "inproc://default"));
+                              m_connection_info.connection_string);
     }
 
     try {
       m_socket.set(zmq::sockopt::linger, 0); // Close connection immediately when close is called
     } catch (zmq::error_t const& err) {
       throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
                               "set linger",
                               "receive",
                               err.what(),
-                              connection_info.value<std::string>("connection_string", "inproc://default"));
+                              m_connection_info.connection_string);
     }
 
     std::vector<std::string> resolved;
     try {
-      utilities::ZmqUri this_uri(connection_info.value<std::string>("connection_string", "inproc://default"));
+      utilities::ZmqUri this_uri(m_connection_info.connection_string);
       resolved = this_uri.get_uri_ip_addresses();
     } catch (utilities::InvalidUri const& err) {
       throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
                               "resolve connection_string",
                               "receive",
                               "An invalid URI was passed",
-                              connection_info.value<std::string>("connection_string", "inproc://default"),
+                              m_connection_info.connection_string,
                               err);
     }
 
     if (resolved.size() == 0) {
       throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
                               "resolve connection_string",
                               "receive",
                               "Unable to resolve connection_string",
-                              connection_info.value<std::string>("connection_string", "inproc://default"));
+                              m_connection_info.connection_string);
     }
     for (auto& connection_string : resolved) {
-      TLOG_DEBUG(TLVL_CONNECTIONSTRING) << "Connection String is " << connection_string;
+      TLOG_DEBUG(TLVL_CONNECTIONSTRING) << m_connection_info.connection_name << ": Connection String is " << connection_string;
       try {
         m_socket.bind(connection_string);
-        m_connection_string = m_socket.get(zmq::sockopt::last_endpoint);
+        m_connection_info.connection_string = m_socket.get(zmq::sockopt::last_endpoint);
         m_socket_connected = true;
         break;
       } catch (zmq::error_t const& err) {
-        ers::error(ZmqOperationError(ERS_HERE, "bind", "receive", err.what(), connection_string));
+        ers::error(ZmqOperationError(
+          ERS_HERE, m_connection_info.connection_name, "bind", "receive", err.what(), connection_string));
       }
     }
     if (!m_socket_connected) {
-      throw ZmqOperationError(ERS_HERE, "bind", "receive", "Bind failed for all resolved connection strings", "");
+      throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
+                              "bind",
+                              "receive",
+                              "Bind failed for all resolved connection strings",
+                              "");
     }
 
     m_callback_adapter.set_receiver(this);
 
-    return m_connection_string;
+    return m_connection_info.connection_string;
   }
 
   bool can_receive() const noexcept override { return m_socket_connected; }
@@ -124,16 +139,15 @@ protected:
     do {
 
       try {
-        TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_HDR) << "Endpoint " << m_connection_string << ": Going to receive header";
+        TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_HDR) << m_connection_info.connection_name << ": Going to receive header";
         res = m_socket.recv(hdr);
-        TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_HDR_2)
-          << "Endpoint " << m_connection_string << ": Recv res=" << res.value_or(0)
+        TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_HDR_2) << m_connection_info.connection_name << ": Recv res=" << res.value_or(0)
           << " for header (hdr.size() == " << hdr.size() << ")";
       } catch (zmq::error_t const& err) {
-        throw ZmqReceiveError(ERS_HERE, err.what(), "header");
+        throw ZmqReceiveError(ERS_HERE, m_connection_info.connection_name, err.what(), "header");
       }
       if (res || hdr.more()) {
-        TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_DATA) << "Endpoint " << m_connection_string << ": Going to receive data";
+        TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_DATA) << m_connection_info.connection_name << ": Going to receive data";
         output.metadata.resize(hdr.size());
         memcpy(&output.metadata[0], hdr.data(), hdr.size());
 
@@ -142,10 +156,10 @@ protected:
         try {
           res = m_socket.recv(msg);
         } catch (zmq::error_t const& err) {
-          throw ZmqReceiveError(ERS_HERE, err.what(), "data");
+          throw ZmqReceiveError(ERS_HERE, m_connection_info.connection_name, err.what(), "data");
         }
         TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_DATA_2)
-          << "Endpoint " << m_connection_string << ": Recv res=" << res.value_or(0)
+          << m_connection_info.connection_name << ": Recv res=" << res.value_or(0)
           << " for data (msg.size() == " << msg.size() << ")";
         output.data.resize(msg.size());
         memcpy(&output.data[0], msg.data(), msg.size());
@@ -156,18 +170,18 @@ protected:
              res.value_or(0) == 0);
 
     if (res.value_or(0) == 0 && !no_tmoexcept_mode) {
-      throw ReceiveTimeoutExpired(ERS_HERE, timeout.count());
+      throw ReceiveTimeoutExpired(ERS_HERE, m_connection_info.connection_name, timeout.count());
     }
 
     TLOG_DEBUG(TLVL_ZMQRECEIVER_RECV_END)
-      << "Endpoint " << m_connection_string << ": Returning output with metadata size " << output.metadata.size()
+      << m_connection_info.connection_name << ": Returning output with metadata size "
+      << output.metadata.size()
       << " and data size " << output.data.size();
     return output;
   }
 
 private:
   zmq::socket_t m_socket;
-  std::string m_connection_string;
   bool m_socket_connected{ false };
   CallbackAdapter m_callback_adapter;
 };

--- a/plugins/ZmqSender.cpp
+++ b/plugins/ZmqSender.cpp
@@ -28,13 +28,13 @@ public:
   ~ZmqSender()
   {
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
-    if (m_connection_string != "" && m_socket_connected) {
+    if (m_connection_info.connection_string != "" && m_socket_connected) {
       try {
-        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << "Setting socket HWM to zero";
+        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << m_connection_info.connection_name << ": Setting socket HWM to zero";
         m_socket.set(zmq::sockopt::sndhwm, 1);
 
-        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR)
-          << "Waiting up to 10s for socket to become writable before disconnecting";
+        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << m_connection_info.connection_name
+          << ": Waiting up to 10s for socket to become writable before disconnecting";
         auto start_time = std::chrono::steady_clock::now();
         while (
           std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() <
@@ -45,65 +45,81 @@ public:
           }
           usleep(1000);
         }
-        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << "Disconnecting socket from " << m_connection_string;
+        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR)
+          << m_connection_info.connection_name << ": Disconnecting socket from " << m_connection_info.connection_string;
 
 
-        m_socket.disconnect(m_connection_string);
+        m_socket.disconnect(m_connection_info.connection_string);
         m_socket_connected = false;
       } catch (zmq::error_t const& err) {
-        ers::error(ZmqOperationError(ERS_HERE, "disconnect", "send", err.what(), m_connection_string));
+        ers::error(ZmqOperationError(ERS_HERE,
+                                     m_connection_info.connection_name,
+                                     "disconnect",
+                                     "send",
+                                     err.what(),
+                                     m_connection_info.connection_string));
       }
     }
     m_socket.close();
   }
 
   bool can_send() const noexcept override { return m_socket_connected; }
-  std::string connect_for_sends(const nlohmann::json& connection_info) override
+  std::string connect_for_sends(const ConnectionInfo& connection_info) override
   {
+    m_connection_info = connection_info;
     try {
       m_socket.set(zmq::sockopt::sndtimeo, 0); // Return immediately if we can't send
     } catch (zmq::error_t const& err) {
       throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
                               "set timeout",
                               "send",
                               err.what(),
-                              connection_info.value<std::string>("connection_string", "inproc://default"));
+                              m_connection_info.connection_string);
     }
 
-    auto hwm = connection_info.value<int>("capacity", 0);
+    auto hwm = connection_info.capacity;
     if (hwm > 0) {
       try {
         m_socket.set(zmq::sockopt::sndhwm, hwm);
       } catch (zmq::error_t const& err) {
         throw ZmqOperationError(ERS_HERE,
+                                m_connection_info.connection_name,
                                 "set hwm",
                                 "send",
                                 err.what(),
-                                connection_info.value<std::string>("connection_string", "inproc://default"));
+                                m_connection_info.connection_string);
       }
     }
 
-    auto connection_string = connection_info.value<std::string>("connection_string", "inproc://default");
+    auto connection_string = m_connection_info.connection_string;
 
     TLOG_DEBUG(TLVL_CONNECTIONSTRING) << "Connection String is " << connection_string;
     try {
       m_socket.set(zmq::sockopt::immediate, 1); // Don't queue messages to incomplete connections
     } catch (zmq::error_t const& err) {
-      throw ZmqOperationError(ERS_HERE, "set immediate mode", "send", err.what(), connection_string);
+      throw ZmqOperationError(
+        ERS_HERE, m_connection_info.connection_name, "set immediate mode", "send", err.what(), connection_string);
     }
 
     try {
       m_socket.connect(connection_string);
-      m_connection_string = m_socket.get(zmq::sockopt::last_endpoint);
+      m_connection_info.connection_string = m_socket.get(zmq::sockopt::last_endpoint);
       m_socket_connected = true;
     } catch (zmq::error_t const& err) {
-      ers::error(ZmqOperationError(ERS_HERE, "connect", "send", err.what(), connection_string));
+      ers::error(ZmqOperationError(
+        ERS_HERE, m_connection_info.connection_name, "connect", "send", err.what(), connection_string));
     }
 
     if (!m_socket_connected) {
-      throw ZmqOperationError(ERS_HERE, "connect", "send", "Operation failed for all resolved connection strings", "");
+      throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
+                              "connect",
+                              "send",
+                              "Operation failed for all resolved connection strings",
+                              "");
     }
-    return m_connection_string;
+    return m_connection_info.connection_string;
   }
 
 protected:
@@ -114,7 +130,7 @@ protected:
              bool no_tmoexcept_mode) override
   {
     TLOG_DEBUG(TLVL_ZMQSENDER_SEND_START)
-      << "Endpoint " << m_connection_string << ": Starting send of " << N << " bytes";
+      << m_connection_info.connection_name << ": Starting send of " << N << " bytes";
     auto start_time = std::chrono::steady_clock::now();
     zmq::send_result_t res{};
     do {
@@ -123,11 +139,11 @@ protected:
       try {
         res = m_socket.send(topic_msg, zmq::send_flags::sndmore);
       } catch (zmq::error_t const& err) {
-        throw ZmqSendError(ERS_HERE, err.what(), topic.size(), topic);
+        throw ZmqSendError(ERS_HERE, m_connection_info.connection_name, err.what(), topic.size(), topic);
       }
 
       if (!res || res != topic.size()) {
-        TLOG_DEBUG(TLVL_ZMQSENDER_SEND_ERR) << "Endpoint " << m_connection_string << ": Unable to send message";
+        TLOG_DEBUG(TLVL_ZMQSENDER_SEND_ERR) << m_connection_info.connection_name << ": Unable to send message";
         continue;
       }
 
@@ -135,7 +151,7 @@ protected:
       try {
         res = m_socket.send(msg, zmq::send_flags::none);
       } catch (zmq::error_t const& err) {
-        throw ZmqSendError(ERS_HERE, err.what(), N, topic);
+        throw ZmqSendError(ERS_HERE, m_connection_info.connection_name, err.what(), N, topic);
       }
 
       if (!res && timeout > duration_t::zero()) {
@@ -144,17 +160,16 @@ protected:
     } while (std::chrono::duration_cast<duration_t>(std::chrono::steady_clock::now() - start_time) < timeout && !res);
 
     if (!res && !no_tmoexcept_mode) {
-      throw SendTimeoutExpired(ERS_HERE, timeout.count());
+      throw SendTimeoutExpired(ERS_HERE, m_connection_info.connection_name, timeout.count());
     }
 
-    TLOG_DEBUG(TLVL_ZMQSENDER_SEND_END) << "Endpoint " << m_connection_string << ": Completed send of " << N
+    TLOG_DEBUG(TLVL_ZMQSENDER_SEND_END) << m_connection_info.connection_name << ": Completed send of " << N
                                         << " bytes";
     return res && res == N;
   }
 
 private:
   zmq::socket_t m_socket;
-  std::string m_connection_string;
   bool m_socket_connected{ false };
 };
 

--- a/plugins/ZmqSubscriber.cpp
+++ b/plugins/ZmqSubscriber.cpp
@@ -38,44 +38,57 @@ public:
         try {
           m_socket.disconnect(conn_string);
         } catch (zmq::error_t const& err) {
-          ers::error(ZmqOperationError(ERS_HERE, "disconnect", "receive", err.what(), conn_string));
+          ers::error(ZmqOperationError(
+            ERS_HERE, m_connection_info.connection_name, "disconnect", "receive", err.what(), conn_string));
         }
       }
     }
     m_socket.close();
   }
 
-  std::string connect_for_receives(const nlohmann::json& connection_info) override
+  std::string connect_for_receives(const ConnectionInfo& connection_info) override
   {
+    m_connection_info = connection_info;
     std::set<std::string> new_connection_strings;
-    if (connection_info.contains("connection_string")) {
-      if (m_connection_strings.count(connection_info.value<std::string>("connection_string", "")) == 0)
-        new_connection_strings.insert(connection_info.value<std::string>("connection_string", ""));
+    if (connection_info.connection_string != "") {
+      new_connection_strings.insert(connection_info.connection_string);
     }
 
-    for (auto& conn_string : connection_info.value<std::vector<std::string>>("connection_strings", {})) {
+    for (auto& conn_string : connection_info.connection_strings) {
       if (m_connection_strings.count(conn_string) == 0)
         new_connection_strings.insert(conn_string);
     }
 
     if (m_connection_strings.size() == 0 && new_connection_strings.size() == 0) {
-      throw ZmqOperationError(ERS_HERE, "resolve connections", "receive", "No valid connection strings passed", "");
+      throw ZmqOperationError(ERS_HERE,
+                              m_connection_info.connection_name,
+                              "resolve connections",
+                              "receive",
+                              "No valid connection strings passed",
+                              "");
     }
 
     if (!m_socket_connected) {
       try {
         m_socket.set(zmq::sockopt::rcvtimeo, 0); // Return immediately if we can't receive
       } catch (zmq::error_t const& err) {
-        throw ZmqOperationError(ERS_HERE, "set timeout", "receive", err.what(), *m_connection_strings.begin());
+        throw ZmqOperationError(ERS_HERE,
+                                m_connection_info.connection_name,
+                                "set timeout",
+                                "receive",
+                                err.what(),
+                                *m_connection_strings.begin());
       }
     }
     for (auto& conn_string : new_connection_strings) {
       try {
-        TLOG_DEBUG(TLVL_CONNECTIONSTRING) << "Connection String is " << conn_string;
+        TLOG_DEBUG(TLVL_CONNECTIONSTRING)
+          << m_connection_info.connection_name << ": Connection String is " << conn_string;
         m_socket.connect(conn_string);
         m_connection_strings.insert(conn_string);
       } catch (zmq::error_t const& err) {
-        ers::error(ZmqOperationError(ERS_HERE, "connect", "receive", err.what(), conn_string));
+        ers::error(ZmqOperationError(
+          ERS_HERE, m_connection_info.connection_name, "connect", "receive", err.what(), conn_string));
       }
     }
     m_socket_connected = true;
@@ -94,7 +107,7 @@ public:
     try {
       m_socket.set(zmq::sockopt::subscribe, topic);
     } catch (zmq::error_t const& err) {
-      throw ZmqSubscribeError(ERS_HERE, err.what(), topic);
+      throw ZmqSubscribeError(ERS_HERE, m_connection_info.connection_name, err.what(), topic);
     }
   }
   void unsubscribe(std::string const& topic) override
@@ -102,7 +115,7 @@ public:
     try {
       m_socket.set(zmq::sockopt::unsubscribe, topic);
     } catch (zmq::error_t const& err) {
-      throw ZmqUnsubscribeError(ERS_HERE, err.what(), topic);
+      throw ZmqUnsubscribeError(ERS_HERE, m_connection_info.connection_name, err.what(), topic);
     }
   }
 
@@ -124,15 +137,16 @@ protected:
     do {
 
       try {
-        TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_HDR) << "Subscriber: Going to receive header";
+        TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_HDR) << m_connection_info.connection_name << ": Going to receive header";
         res = m_socket.recv(hdr);
         TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_HDR_2)
-          << "Subscriber: Recv res=" << res.value_or(0) << " for header (hdr.size() == " << hdr.size() << ")";
+          << m_connection_info.connection_name << ": Recv res=" << res.value_or(0)
+          << " for header (hdr.size() == " << hdr.size() << ")";
       } catch (zmq::error_t const& err) {
-        throw ZmqReceiveError(ERS_HERE, err.what(), "header");
+        throw ZmqReceiveError(ERS_HERE, m_connection_info.connection_name, err.what(), "header");
       }
       if (res || hdr.more()) {
-        TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_DATA) << "Subscriber: Going to receive data";
+        TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_DATA) << m_connection_info.connection_name << ": Going to receive data";
         output.metadata.resize(hdr.size());
         memcpy(&output.metadata[0], hdr.data(), hdr.size());
 
@@ -141,10 +155,11 @@ protected:
         try {
           res = m_socket.recv(msg);
         } catch (zmq::error_t const& err) {
-          throw ZmqReceiveError(ERS_HERE, err.what(), "data");
+          throw ZmqReceiveError(ERS_HERE, m_connection_info.connection_name, err.what(), "data");
         }
         TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_DATA_2)
-          << "Subscriber: Recv res=" << res.value_or(0) << " for data (msg.size() == " << msg.size() << ")";
+          << m_connection_info.connection_name << ": Recv res=" << res.value_or(0)
+          << " for data (msg.size() == " << msg.size() << ")";
         output.data.resize(msg.size());
         memcpy(&output.data[0], msg.data(), msg.size());
       } else if (timeout > duration_t::zero()) {
@@ -154,11 +169,12 @@ protected:
              res.value_or(0) == 0);
 
     if (res.value_or(0) == 0 && !no_tmoexcept_mode) {
-      throw ReceiveTimeoutExpired(ERS_HERE, timeout.count());
+      throw ReceiveTimeoutExpired(ERS_HERE, m_connection_info.connection_name, timeout.count());
     }
 
-    TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_END) << "Subscriber: Returning output with metadata size "
-                                            << output.metadata.size() << " and data size " << output.data.size();
+    TLOG_DEBUG(TLVL_ZMQSUBSCRIBER_RECV_END)
+      << m_connection_info.connection_name << ": Returning output with metadata size " << output.metadata.size()
+      << " and data size " << output.data.size();
     return output;
   }
 

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -22,7 +22,7 @@ dunedaq::ipm::Receiver::receive(const duration_t& timeout, message_size_t bytes,
   if (bytes != s_any_size) {
     auto received_size = static_cast<message_size_t>(message.data.size());
     if (received_size != bytes) {
-      throw UnexpectedNumberOfBytes(ERS_HERE, received_size, bytes);
+      throw UnexpectedNumberOfBytes(ERS_HERE, m_connection_info.connection_name, received_size, bytes);
     }
   }
 

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -29,7 +29,7 @@ dunedaq::ipm::Sender::send(const void* message,
   }
 
   if (!message) {
-    throw NullPointerPassedToSend(ERS_HERE);
+    throw NullPointerPassedToSend(ERS_HERE, m_connection_info.connection_name);
   }
 
   auto res = send_(message, message_size, timeout, metadata, no_tmoexcept_mode);

--- a/test/apps/zmq_recv.cpp
+++ b/test/apps/zmq_recv.cpp
@@ -53,7 +53,8 @@ main(int argc, char* argv[])
 
   // Receiver side
   std::shared_ptr<Receiver> receiver = make_ipm_receiver("ZmqReceiver");
-  receiver->connect_for_receives({ { "connection_string", conString } });
+  Receiver::ConnectionInfo conn_info("zmq_recv", conString);
+  receiver->connect_for_receives(conn_info);
 
   std::map<uint32_t, uint32_t> last_received_sequence; // NOLINT(build/unsigned)
   int64_t first_latency = 0;

--- a/test/apps/zmq_send.cpp
+++ b/test/apps/zmq_send.cpp
@@ -62,7 +62,8 @@ main(int argc, char* argv[])
   }
 
   std::shared_ptr<dunedaq::ipm::Sender> sender = dunedaq::ipm::make_ipm_sender("ZmqSender");
-  sender->connect_for_sends({ { "connection_string", conString } });
+  dunedaq::ipm::Sender::ConnectionInfo conn_info("zmq_send", conString);
+  sender->connect_for_sends(conn_info);
 
   std::vector<char> message(packetSize, 0);
   *reinterpret_cast<uint32_t*>(message.data()) = id; // NOLINT

--- a/unittest/Receiver_test.cxx
+++ b/unittest/Receiver_test.cxx
@@ -39,7 +39,7 @@ public:
   }
   void unregister_callback() override { m_callback_adapter.clear_callback(); }
 
-  std::string connect_for_receives(const nlohmann::json& /* connection_info */) override
+  std::string connect_for_receives(const ConnectionInfo& /* connection_info */) override
   {
     m_can_receive = true;
     m_callback_adapter.set_receiver(this);
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE(StatusChecks)
 
   BOOST_REQUIRE(!the_receiver.can_receive());
 
-  nlohmann::json j;
-  the_receiver.connect_for_receives(j);
+  Receiver::ConnectionInfo ci;
+  the_receiver.connect_for_receives(ci);
   BOOST_REQUIRE(the_receiver.can_receive());
 
   BOOST_REQUIRE_NO_THROW(the_receiver.receive(Receiver::s_no_block));
@@ -111,8 +111,8 @@ BOOST_AUTO_TEST_CASE(Callback)
 {
   ReceiverImpl the_receiver;
 
-  nlohmann::json j;
-  the_receiver.connect_for_receives(j);
+  Receiver::ConnectionInfo ci;
+  the_receiver.connect_for_receives(ci);
   BOOST_REQUIRE(the_receiver.can_receive());
 
   std::atomic<size_t> callback_call_count = 0;

--- a/unittest/Sender_test.cxx
+++ b/unittest/Sender_test.cxx
@@ -30,7 +30,7 @@ public:
   {
   }
 
-  std::string connect_for_sends(const nlohmann::json& /* connection_info */) override
+  std::string connect_for_sends(const ConnectionInfo& /* connection_info */) override
   {
     m_can_send = true;
     return "";
@@ -76,8 +76,8 @@ BOOST_AUTO_TEST_CASE(StatusChecks)
 
   BOOST_REQUIRE(!the_sender.can_send());
 
-  nlohmann::json j;
-  the_sender.connect_for_sends(j);
+  Sender::ConnectionInfo ci;
+  the_sender.connect_for_sends(ci);
   BOOST_REQUIRE(the_sender.can_send());
 
   BOOST_REQUIRE_NO_THROW(the_sender.send(random_data.data(), random_data.size(), Sender::s_no_block));
@@ -93,8 +93,8 @@ BOOST_AUTO_TEST_CASE(StatusChecks)
 BOOST_AUTO_TEST_CASE(BadInput)
 {
   SenderImpl the_sender;
-  nlohmann::json j;
-  the_sender.connect_for_sends(j);
+  Sender::ConnectionInfo ci;
+  the_sender.connect_for_sends(ci);
 
   const char* bad_bytes = nullptr;
   BOOST_REQUIRE_EXCEPTION(the_sender.send(bad_bytes, 10, Sender::s_no_block),

--- a/unittest/Subscriber_test.cxx
+++ b/unittest/Subscriber_test.cxx
@@ -35,7 +35,7 @@ public:
   {
   }
 
-  std::string connect_for_receives(const nlohmann::json& /* connection_info */) override
+  std::string connect_for_receives(const ConnectionInfo& /* connection_info */) override
   {
     m_can_receive = true;
     m_callback_adapter.set_receiver(this);
@@ -91,8 +91,8 @@ BOOST_AUTO_TEST_CASE(StatusChecks)
 
   BOOST_REQUIRE(!the_subscriber.can_receive());
 
-  nlohmann::json j;
-  the_subscriber.connect_for_receives(j);
+  Receiver::ConnectionInfo ci;
+  the_subscriber.connect_for_receives(ci);
   BOOST_REQUIRE(the_subscriber.can_receive());
 
   the_subscriber.subscribe("TEST");
@@ -123,8 +123,8 @@ BOOST_AUTO_TEST_CASE(Callback)
 {
   SubscriberImpl the_subscriber;
 
-  nlohmann::json j;
-  the_subscriber.connect_for_receives(j);
+  Receiver::ConnectionInfo ci;
+  the_subscriber.connect_for_receives(ci);
   BOOST_REQUIRE(the_subscriber.can_receive());
 
   std::atomic<size_t> callback_call_count = 0;

--- a/unittest/ZmqPubSub_test.cxx
+++ b/unittest/ZmqPubSub_test.cxx
@@ -39,10 +39,11 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
   BOOST_REQUIRE(the_sender != nullptr);
   BOOST_REQUIRE(!the_sender->can_send());
 
-  nlohmann::json config_json;
-  config_json["connection_string"] = "inproc://default";
-  the_sender->connect_for_sends(config_json);
-  the_receiver->connect_for_receives(config_json);
+  Sender::ConnectionInfo sender_config("test_sender", "inproc://default");
+  Receiver::ConnectionInfo receiver_config("test_receiver", "inproc://default");
+  
+  the_sender->connect_for_sends(sender_config);
+  the_receiver->connect_for_receives(receiver_config);
 
   BOOST_REQUIRE(the_receiver->can_receive());
   BOOST_REQUIRE(the_sender->can_send());
@@ -85,10 +86,10 @@ BOOST_AUTO_TEST_CASE(CallbackTest)
   BOOST_REQUIRE(the_sender != nullptr);
   BOOST_REQUIRE(!the_sender->can_send());
 
-  nlohmann::json config_json;
-  config_json["connection_string"] = "inproc://default";
-  the_sender->connect_for_sends(config_json);
-  the_receiver->connect_for_receives(config_json);
+  Sender::ConnectionInfo sender_config("test_sender", "inproc://default");
+  Receiver::ConnectionInfo receiver_config("test_receiver", "inproc://default");
+  the_sender->connect_for_sends(sender_config);
+  the_receiver->connect_for_receives(receiver_config);
 
   BOOST_REQUIRE(the_receiver->can_receive());
   BOOST_REQUIRE(the_sender->can_send());
@@ -142,15 +143,12 @@ BOOST_AUTO_TEST_CASE(MultiplePublishers)
   auto second_publisher = make_ipm_sender("ZmqPublisher");
   auto the_subscriber = make_ipm_subscriber("ZmqSubscriber");
 
-  nlohmann::json first_json;
-  nlohmann::json second_json;
-  nlohmann::json sub_json;
-  first_json["connection_string"] = "inproc://foo";
-  first_publisher->connect_for_sends(first_json);
-  second_json["connection_string"] = "inproc://bar";
-  second_publisher->connect_for_sends(second_json);
-  sub_json["connection_strings"] = { "inproc://foo", "inproc://bar" };
-  the_subscriber->connect_for_receives(sub_json);
+  Sender::ConnectionInfo first_sender_config("test_sender", "inproc://foo");
+  Sender::ConnectionInfo second_sender_config("test_sender", "inproc://bar");
+  Receiver::ConnectionInfo receiver_config("test_receiver", "", { "inproc://foo", "inproc://bar" });
+  first_publisher->connect_for_sends(first_sender_config);
+  second_publisher->connect_for_sends(second_sender_config);
+  the_subscriber->connect_for_receives(receiver_config);
 
   the_subscriber->subscribe("testTopic");
 

--- a/unittest/ZmqPublisher_test.cxx
+++ b/unittest/ZmqPublisher_test.cxx
@@ -34,22 +34,22 @@ BOOST_AUTO_TEST_CASE(Errors)
   BOOST_REQUIRE(the_sender != nullptr);
   BOOST_REQUIRE(!the_sender->can_send());
 
-  nlohmann::json config_json;
+  Sender::ConnectionInfo config;
 
-  config_json["connection_string"] = "not a uri";
-  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "not a uri";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("invalid URI") != std::string::npos;
   });
   BOOST_REQUIRE(!the_sender->can_send());
 
-  config_json["connection_string"] = "tcp://thishostddoesnotexist";
-  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "tcp://thishostddoesnotexist";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("Unable to resolve connection_string") != std::string::npos;
   });
   BOOST_REQUIRE(!the_sender->can_send());
 
-  config_json["connection_string"] = "badproto://default";
-  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "badproto://default";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("while calling bind on the ZMQ send socket") != std::string::npos;
   });
   BOOST_REQUIRE(!the_sender->can_send());

--- a/unittest/ZmqReceiver_test.cxx
+++ b/unittest/ZmqReceiver_test.cxx
@@ -40,24 +40,33 @@ BOOST_AUTO_TEST_CASE(Errors)
   BOOST_REQUIRE(the_receiver != nullptr);
   BOOST_REQUIRE(!the_receiver->can_receive());
 
-  nlohmann::json config_json;
+  Receiver::ConnectionInfo config("ZmqReceiverTestConn");
 
-  config_json["connection_string"] = "not a uri";
-  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "not a uri";
+  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("invalid URI") != std::string::npos;
   });
   BOOST_REQUIRE(!the_receiver->can_receive());
 
-  config_json["connection_string"] = "tcp://thishostddoesnotexist";
-  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "tcp://thishostddoesnotexist";
+  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("Unable to resolve connection_string") != std::string::npos;
   });
   BOOST_REQUIRE(!the_receiver->can_receive());
 
-  config_json["connection_string"] = "badproto://default";
-  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "badproto://default";
+  BOOST_REQUIRE_EXCEPTION(the_receiver->connect_for_receives(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("while calling bind on the ZMQ receive socket") != std::string::npos;
   });
   BOOST_REQUIRE(!the_receiver->can_receive());
+
+  config.connection_string = "inproc://default";
+  config.connection_name = "timeout_test";
+  the_receiver->connect_for_receives(config);
+  BOOST_REQUIRE(the_receiver->can_receive());
+  BOOST_REQUIRE_EXCEPTION(the_receiver->receive(Receiver::s_no_block), ReceiveTimeoutExpired, [&](ReceiveTimeoutExpired e) {
+      TLOG() << e.what();
+    return std::string(e.what()).find("Unable to receive within timeout period") != std::string::npos;
+    });
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/ZmqSendReceive_test.cxx
+++ b/unittest/ZmqSendReceive_test.cxx
@@ -30,9 +30,10 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
   BOOST_REQUIRE(the_sender != nullptr);
   BOOST_REQUIRE(!the_sender->can_send());
 
-  nlohmann::json empty_json = nlohmann::json::object();
-  the_receiver->connect_for_receives(empty_json);
-  the_sender->connect_for_sends(empty_json);
+  Sender::ConnectionInfo send_info("ZmqSendReceive", "inproc://default");
+  Receiver::ConnectionInfo recv_info("ZmqSendReceive", "inproc://default");
+  the_receiver->connect_for_receives(recv_info);
+  the_sender->connect_for_sends(send_info);
 
   BOOST_REQUIRE(the_receiver->can_receive());
   BOOST_REQUIRE(the_sender->can_send());
@@ -59,9 +60,10 @@ BOOST_AUTO_TEST_CASE(CallbackTest)
   BOOST_REQUIRE(the_sender != nullptr);
   BOOST_REQUIRE(!the_sender->can_send());
 
-  nlohmann::json empty_json = nlohmann::json::object();
-  the_receiver->connect_for_receives(empty_json);
-  the_sender->connect_for_sends(empty_json);
+  Sender::ConnectionInfo send_info("ZmqSendReceive-Callbacks", "inproc://default");
+  Receiver::ConnectionInfo recv_info("ZmqSendReceive-Callbacks", "inproc://default");
+  the_receiver->connect_for_receives(recv_info);
+  the_sender->connect_for_sends(send_info);
 
   BOOST_REQUIRE(the_receiver->can_receive());
   BOOST_REQUIRE(the_sender->can_send());

--- a/unittest/ZmqSender_test.cxx
+++ b/unittest/ZmqSender_test.cxx
@@ -33,22 +33,22 @@ BOOST_AUTO_TEST_CASE(Errors)
   BOOST_REQUIRE(the_sender != nullptr);
   BOOST_REQUIRE(!the_sender->can_send());
 
-  nlohmann::json config_json;
+  Sender::ConnectionInfo config("ZmqSenderTestConn");
 
-  config_json["connection_string"] = "not a uri";
-  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "not a uri";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("Operation failed for all resolved connection strings") != std::string::npos;
   });
   BOOST_REQUIRE(!the_sender->can_send());
   
-  config_json["connection_string"] = "tcp://thishostddoesnotexist";
-  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "tcp://thishostddoesnotexist";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("Operation failed for all resolved connection strings") != std::string::npos;
   });
   BOOST_REQUIRE(!the_sender->can_send());
   
-  config_json["connection_string"] = "badproto://default";
-  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config_json), ZmqOperationError, [&](ZmqOperationError e) {
+  config.connection_string = "badproto://default";
+  BOOST_REQUIRE_EXCEPTION(the_sender->connect_for_sends(config), ZmqOperationError, [&](ZmqOperationError e) {
     return std::string(e.what()).find("Operation failed for all resolved connection strings") != std::string::npos;
   });
   BOOST_REQUIRE(!the_sender->can_send());

--- a/unittest/ZmqSubscriber_test.cxx
+++ b/unittest/ZmqSubscriber_test.cxx
@@ -36,18 +36,18 @@ BOOST_AUTO_TEST_CASE(Errors)
   BOOST_REQUIRE(the_subscriber != nullptr);
   BOOST_REQUIRE(!the_subscriber->can_receive());
 
-  nlohmann::json config_json;
+  Receiver::ConnectionInfo config("ZmqSubscriberTestConn");
 
-  config_json["connection_string"] = "not a uri";
-  the_subscriber->connect_for_receives(config_json);
+  config.connection_string = "not a uri";
+  the_subscriber->connect_for_receives(config);
   BOOST_REQUIRE(the_subscriber->can_receive());
 
-  config_json["connection_string"] = "tcp://thishostddoesnotexist";
-  the_subscriber->connect_for_receives(config_json);
+  config.connection_string = "tcp://thishostddoesnotexist";
+  the_subscriber->connect_for_receives(config);
   BOOST_REQUIRE(the_subscriber->can_receive());
 
-  config_json["connection_string"] = "badproto://default";
-  the_subscriber->connect_for_receives(config_json);
+  config.connection_string = "badproto://default";
+  the_subscriber->connect_for_receives(config);
   BOOST_REQUIRE(the_subscriber->can_receive());
 }
 


### PR DESCRIPTION
Update configuration paradigm for IPM, pass structs with configuration information to connect_for_sends and connect_for_receives.

Add connection_name parameter to configuration, use this when logging so that it is clear which connection is having particular issues.

# Description

Resolves #112 

This PR replaces the JSON configuration of ipm (in connect_for_receives and connect_for_sends) with configuration structs defined in Receiver and Sender.  This removes the JSON dependency from ipm.

## Type of change

- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

Note that this change needs to be tested together with DUNE-DAQ/iomanager#127.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

