### PR TITLE
Add a data_pending() method to Receiver

### DIFF
--- a/include/ipm/Receiver.hpp
+++ b/include/ipm/Receiver.hpp
@@ -102,6 +102,7 @@ public:
   };
 
   Response receive(const duration_t& timeout, message_size_t num_bytes = s_any_size, bool no_tmoexcept_mode = false);
+  virtual bool data_pending() = 0;
 
   virtual void register_callback(std::function<void(Response&)>) = 0;
   virtual void unregister_callback() = 0;

--- a/plugins/ZmqReceiver.cpp
+++ b/plugins/ZmqReceiver.cpp
@@ -112,6 +112,17 @@ public:
   }
   void unregister_callback() override { m_callback_adapter.clear_callback(); }
 
+  bool data_pending() override
+  {
+    try {
+      auto events = m_socket.get(zmq::sockopt::events);
+      return (events & ZMQ_POLLIN) != 0;
+    } catch (zmq::error_t const& err) {
+      ers::error(ZmqOperationError(ERS_HERE, "get events sockopt", "data_pending", err.what(), m_connection_string));
+    }
+    return false;
+  }
+
 protected:
   Receiver::Response receive_(const duration_t& timeout, bool no_tmoexcept_mode) override
   {

--- a/plugins/ZmqReceiver.cpp
+++ b/plugins/ZmqReceiver.cpp
@@ -133,7 +133,7 @@ public:
       auto events = m_socket.get(zmq::sockopt::events);
       return (events & ZMQ_POLLIN) != 0;
     } catch (zmq::error_t const& err) {
-      ers::error(ZmqOperationError(ERS_HERE, "get events sockopt", "data_pending", err.what(), m_connection_string));
+      ers::error(ZmqOperationError(ERS_HERE, m_connection_info.connection_name, "get events sockopt", "data_pending", err.what(), m_connection_info.connection_string));
     }
     return false;
   }

--- a/plugins/ZmqSubscriber.cpp
+++ b/plugins/ZmqSubscriber.cpp
@@ -106,6 +106,18 @@ public:
     }
   }
 
+  bool data_pending() override
+  {
+    try {
+      auto events = m_socket.get(zmq::sockopt::events);
+      return (events & ZMQ_POLLIN) != 0;
+    } catch (zmq::error_t const& err) {
+      ers::error(
+        ZmqOperationError(ERS_HERE, "get events sockopt", "data_pending", err.what(), *m_connection_strings.begin()));
+    }
+    return false;
+  }
+
   void register_callback(std::function<void(Response&)> callback) override
   {
     m_callback_adapter.set_callback(callback);

--- a/plugins/ZmqSubscriber.cpp
+++ b/plugins/ZmqSubscriber.cpp
@@ -126,7 +126,7 @@ public:
       return (events & ZMQ_POLLIN) != 0;
     } catch (zmq::error_t const& err) {
       ers::error(
-        ZmqOperationError(ERS_HERE, "get events sockopt", "data_pending", err.what(), *m_connection_strings.begin()));
+        ZmqOperationError(ERS_HERE, m_connection_info.connection_name, "get events sockopt", "data_pending", err.what(), *m_connection_strings.begin()));
     }
     return false;
   }

--- a/unittest/Receiver_test.cxx
+++ b/unittest/Receiver_test.cxx
@@ -52,6 +52,8 @@ public:
     m_can_receive = false;
   }
 
+  bool data_pending() override { return true; }
+
 protected:
   Receiver::Response receive_(const duration_t& /* timeout */, bool /*no_tmoexcept_mode*/) override
   {

--- a/unittest/Subscriber_test.cxx
+++ b/unittest/Subscriber_test.cxx
@@ -59,6 +59,8 @@ public:
 
   std::set<std::string> get_subscriptions() const { return m_subscriptions; }
 
+  bool data_pending() override { return true; }
+
 protected:
   Receiver::Response receive_(const duration_t& /* timeout */, bool /*no_tmoexcept_mode*/) override
   {

--- a/unittest/ZmqPubSub_test.cxx
+++ b/unittest/ZmqPubSub_test.cxx
@@ -47,6 +47,8 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
   BOOST_REQUIRE(the_receiver->can_receive());
   BOOST_REQUIRE(the_sender->can_send());
 
+  BOOST_REQUIRE(!the_receiver->data_pending());
+  
   the_receiver->subscribe("testTopic");
 
   std::vector<char> test_data{ 'T', 'E', 'S', 'T' };
@@ -59,7 +61,9 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
     [&](dunedaq::ipm::ReceiveTimeoutExpired) { return elapsed_time_milliseconds(before_recv) >= 100; });
 
   the_sender->send(test_data.data(), test_data.size(), Sender::s_no_block, "testTopic");
+  BOOST_REQUIRE(the_receiver->data_pending());
   auto response = the_receiver->receive(Receiver::s_block);
+  BOOST_REQUIRE(!the_receiver->data_pending());
   BOOST_REQUIRE_EQUAL(response.data.size(), 4);
   BOOST_REQUIRE_EQUAL(response.data[0], 'T');
   BOOST_REQUIRE_EQUAL(response.data[1], 'E');
@@ -68,6 +72,7 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
 
   the_receiver->unsubscribe("testTopic");
   the_sender->send(test_data.data(), test_data.size(), Sender::s_no_block, "testTopic");
+  BOOST_REQUIRE(!the_receiver->data_pending());
   BOOST_REQUIRE_EXCEPTION(
     the_receiver->receive(std::chrono::milliseconds(2000)),
     dunedaq::ipm::ReceiveTimeoutExpired,
@@ -134,6 +139,7 @@ BOOST_AUTO_TEST_CASE(CallbackTest)
   BOOST_REQUIRE_EQUAL(message_received, false);
   auto response = the_receiver->receive(Receiver::s_block);
   BOOST_REQUIRE_EQUAL(response.data.size(), test_data.size());
+  BOOST_REQUIRE(!the_receiver->data_pending());
 }
 
 BOOST_AUTO_TEST_CASE(MultiplePublishers)
@@ -170,6 +176,7 @@ BOOST_AUTO_TEST_CASE(MultiplePublishers)
   BOOST_REQUIRE_EQUAL(response2.data[1], 'E');
   BOOST_REQUIRE_EQUAL(response2.data[2], 'S');
   BOOST_REQUIRE_EQUAL(response2.data[3], 'T');
+  BOOST_REQUIRE(!the_subscriber->data_pending());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/ZmqSendReceive_test.cxx
+++ b/unittest/ZmqSendReceive_test.cxx
@@ -25,6 +25,7 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
   auto the_receiver = make_ipm_receiver("ZmqReceiver");
   BOOST_REQUIRE(the_receiver != nullptr);
   BOOST_REQUIRE(!the_receiver->can_receive());
+  BOOST_REQUIRE(!the_receiver->data_pending());
 
   auto the_sender = make_ipm_sender("ZmqSender");
   BOOST_REQUIRE(the_sender != nullptr);
@@ -35,12 +36,16 @@ BOOST_AUTO_TEST_CASE(SendReceiveTest)
   the_sender->connect_for_sends(empty_json);
 
   BOOST_REQUIRE(the_receiver->can_receive());
+  BOOST_REQUIRE(!the_receiver->data_pending());
   BOOST_REQUIRE(the_sender->can_send());
 
   std::vector<char> test_data{ 'T', 'E', 'S', 'T' };
 
   the_sender->send(test_data.data(), test_data.size(), Sender::s_no_block);
+  BOOST_REQUIRE(the_receiver->data_pending());
   auto response = the_receiver->receive(Receiver::s_block);
+  BOOST_REQUIRE(!the_receiver->data_pending());
+
   BOOST_REQUIRE_EQUAL(response.data.size(), 4);
   BOOST_REQUIRE_EQUAL(response.data[0], 'T');
   BOOST_REQUIRE_EQUAL(response.data[1], 'E');


### PR DESCRIPTION
# Description

Implement method required by https://github.com/DUNE-DAQ/iomanager/pull/129, via the ZMQ_EVENTS ZeroMQ socket option.


## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

This change should be tested together with DUNE-DAQ/iomanager#129.  N.B that we should also clone `dfmodules`, `fdreadoutlibs`, `fdreadoutmodules`, `trigger`, and `hsilibs` into our software areas when testing these changes.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas

