### PR TITLE
Only increment the number of received messages in the Receiver::receive() method if the message is not empty.

### DIFF
--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -26,8 +26,11 @@ dunedaq::ipm::Receiver::receive(const duration_t& timeout, message_size_t bytes,
     }
   }
 
-  m_bytes += message.data.size();
-  ++m_messages;
+  // 18-May-2026, KAB: only increment the opmon counters if a non-empty message was received
+  if (message.data.size() > 0) {
+    m_bytes += message.data.size();
+    ++m_messages;
+  }
 
   return message;
 }


### PR DESCRIPTION
# Description

While running some system tests, I noticed that the number of received messages reported in the opmon ReceiverInfo struct didn't always make sense.  For example, in a test that had no inhibit messages, it reported that the number of trigger_inhibit messages were non-zero, even though the number of message bytes was zero.

This PR contains a proposed fix.

Here are suggested instructions for testing the fix:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260518_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
git clone https://github.com/DUNE-DAQ/iomanager.git -b develop
git clone https://github.com/DUNE-DAQ/ipm.git -b develop
git clone https://github.com/DUNE-DAQ/trigger.git -b develop
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh --verbosity 2 -k min

cd /tmp/pytest-of-${USER}/pytest-current/runcurrent
info_file_collator info*.json
grep -A 16 'trigger_inhibit' opmon_collated.json | grep -A 15 -B 1 'ReceiverInfo'

echo ""
echo -e "\U1F535 \U2705 Note that numbers of inhibit messages are non-zero even though the numbers of bytes are zero. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd $DBT_AREA_ROOT/sourcecode/ipm
git checkout kbiery/received_message_opmon_fix
cd ../../

dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh --verbosity 2 -k min

cd /tmp/pytest-of-${USER}/pytest-current/runcurrent
info_file_collator info*.json
grep -A 16 'trigger_inhibit' opmon_collated.json | grep -A 15 -B 1 'ReceiverInfo'

echo ""
echo -e "\U1F535 \U2705 Note that numbers of inhibit messages and bytes are both now zero. \U2705 \U1F535"
echo ""
echo ""

cd $DBT_AREA_ROOT
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
