### PR TITLE
Remove code that checks for ZMQ_POLLOUT

### DIFF
--- a/plugins/ZmqPublisher.cpp
+++ b/plugins/ZmqPublisher.cpp
@@ -31,22 +31,6 @@ public:
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (m_connection_info.connection_string != "" && m_socket_connected) {
       try {
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << m_connection_info.connection_name << ": Setting socket HWM to zero";
-        m_socket.set(zmq::sockopt::sndhwm, 1);
-
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR)
-          << m_connection_info.connection_name
-          << ": Waiting up to 10s for socket to become writable before disconnecting";
-        auto start_time = std::chrono::steady_clock::now();
-        while (
-          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() <
-          10000) {
-          auto events = m_socket.get(zmq::sockopt::events);
-          if ((events & ZMQ_POLLOUT) != 0) {
-            break;
-          }
-          usleep(1000);
-        }
         TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR)
           << m_connection_info.connection_name << ": Disconnecting socket from " << m_connection_info.connection_string;
 

--- a/plugins/ZmqSender.cpp
+++ b/plugins/ZmqSender.cpp
@@ -30,21 +30,6 @@ public:
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (m_connection_info.connection_string != "" && m_socket_connected) {
       try {
-        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << m_connection_info.connection_name << ": Setting socket HWM to zero";
-        m_socket.set(zmq::sockopt::sndhwm, 1);
-
-        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << m_connection_info.connection_name
-          << ": Waiting up to 10s for socket to become writable before disconnecting";
-        auto start_time = std::chrono::steady_clock::now();
-        while (
-          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() <
-          10000) {
-          auto events = m_socket.get(zmq::sockopt::events);
-          if ((events & ZMQ_POLLOUT) != 0) {
-            break;
-          }
-          usleep(1000);
-        }
         TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR)
           << m_connection_info.connection_name << ": Disconnecting socket from " << m_connection_info.connection_string;
 


### PR DESCRIPTION


# Description

Remove code that checks for ZMQ_POLLOUT
It appears to never be set, even when the receive side is left running (and there are no messages in the buffer).

This removes the loop checking for the ZMQ_POLLOUT event indicating that a message may be sent to the ZMQ channel without blocking. This was added in an attempt to ensure that the receiver had adequate time to receive messages before destructing the socket connection, but causes unnecessary delays at `scrap` and Run Control to time out and terminate the application.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_
Additional testing welcome

