### PR TITLE
Cherry-picked Eric's ZMQ_POLLOUT fix for consideration in the 5.6.1 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(ipm VERSION 4.0.0)
+project(ipm VERSION 4.0.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/ZmqPublisher.cpp
+++ b/plugins/ZmqPublisher.cpp
@@ -31,22 +31,6 @@ public:
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (m_connection_info.connection_string != "" && m_socket_connected) {
       try {
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR) << m_connection_info.connection_name << ": Setting socket HWM to zero";
-        m_socket.set(zmq::sockopt::sndhwm, 1);
-
-        TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR)
-          << m_connection_info.connection_name
-          << ": Waiting up to 10s for socket to become writable before disconnecting";
-        auto start_time = std::chrono::steady_clock::now();
-        while (
-          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() <
-          10000) {
-          auto events = m_socket.get(zmq::sockopt::events);
-          if ((events & ZMQ_POLLOUT) != 0) {
-            break;
-          }
-          usleep(1000);
-        }
         TLOG_DEBUG(TLVL_ZMQPUBLISHER_DESTRUCTOR)
           << m_connection_info.connection_name << ": Disconnecting socket from " << m_connection_info.connection_string;
 

--- a/plugins/ZmqSender.cpp
+++ b/plugins/ZmqSender.cpp
@@ -30,21 +30,6 @@ public:
     // Probably (cpp)zmq does this in the socket dtor anyway, but I guess it doesn't hurt to be explicit
     if (m_connection_info.connection_string != "" && m_socket_connected) {
       try {
-        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << m_connection_info.connection_name << ": Setting socket HWM to zero";
-        m_socket.set(zmq::sockopt::sndhwm, 1);
-
-        TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR) << m_connection_info.connection_name
-          << ": Waiting up to 10s for socket to become writable before disconnecting";
-        auto start_time = std::chrono::steady_clock::now();
-        while (
-          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count() <
-          10000) {
-          auto events = m_socket.get(zmq::sockopt::events);
-          if ((events & ZMQ_POLLOUT) != 0) {
-            break;
-          }
-          usleep(1000);
-        }
         TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR)
           << m_connection_info.connection_name << ": Disconnecting socket from " << m_connection_info.connection_string;
 


### PR DESCRIPTION
# Description

This PR is a copy of #124.  Its target is the v5.6.1 patch release.  

At the SWI&T meeting today, the consensus was that we **should** include this change in the patch release.

Suggested instructions for testing:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt fddaq-v5.6.0
dbt-create fddaq-v5.6.0-a9 ${DATE_PREFIX}FDv5.6.0Test_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDv5.6.0Test_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/ipm.git -b kbiery/erics_zmqpollout_fix
git clone https://github.com/DUNE-DAQ/iomanager.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/dfmodules.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/hsilibs.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/trigger.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b fddaq-v5.6.0
git clone https://github.com/DUNE-DAQ/fdreadoutlibs.git -b fddaq-v5.6.0
git clone https://github.com/DUNE-DAQ/fdreadoutmodules.git -b fddaq-v5.6.0
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k minimal

echo ""
echo -e "\U1F535 \U2705 Note that the process exit codes are all zero and the scrap transition only took a couple of seconds. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
