### PR TITLE
Introduce a short usleep before retrying when send fails

### DIFF
--- a/plugins/ZmqSender.cpp
+++ b/plugins/ZmqSender.cpp
@@ -33,7 +33,6 @@ public:
         TLOG_DEBUG(TLVL_ZMQSENDER_DESTRUCTOR)
           << m_connection_info.connection_name << ": Disconnecting socket from " << m_connection_info.connection_string;
 
-
         m_socket.disconnect(m_connection_info.connection_string);
         m_socket_connected = false;
       } catch (zmq::error_t const& err) {
@@ -128,6 +127,7 @@ protected:
       }
 
       if (!res || res != topic.size()) {
+        usleep(1000);
         TLOG_DEBUG(TLVL_ZMQSENDER_SEND_ERR) << m_connection_info.connection_name << ": Unable to send message";
         continue;
       }
@@ -148,8 +148,7 @@ protected:
       throw SendTimeoutExpired(ERS_HERE, m_connection_info.connection_name, timeout.count());
     }
 
-    TLOG_DEBUG(TLVL_ZMQSENDER_SEND_END) << m_connection_info.connection_name << ": Completed send of " << N
-                                        << " bytes";
+    TLOG_DEBUG(TLVL_ZMQSENDER_SEND_END) << m_connection_info.connection_name << ": Completed send of " << N << " bytes";
     return res && res == N;
   }
 


### PR DESCRIPTION
# Description

Add a short usleep when the send fails to reduce the number of messages printed and allow more time for the issue to clear before retrying.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

